### PR TITLE
'function' type support via `process_type` aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+venv
 
 # Installer logs
 pip-log.txt
@@ -25,6 +26,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.cache
 
 # Translations
 *.mo

--- a/eth_abi/utils/parsing.py
+++ b/eth_abi/utils/parsing.py
@@ -7,6 +7,15 @@ from eth_utils import (
 
 
 def process_type(typ):
+    if typ == 'function':
+        return process_strict_type('bytes24')
+    elif typ in ('int', 'uint'):
+        return process_strict_type(typ + '256')
+    else:
+        return process_strict_type(typ)
+
+
+def process_strict_type(typ):
     # Crazy reg expression to separate out base type component (eg. uint),
     # size (eg. 256, 128x128, none), array component (eg. [], [45], none)
     regexp = '([a-z]*)([0-9]*x?[0-9]*)((\[[0-9]*\])*)'

--- a/tests/utility/test_parsing.py
+++ b/tests/utility/test_parsing.py
@@ -1,0 +1,18 @@
+
+import pytest
+
+from eth_abi.utils.parsing import (
+    process_type,
+)
+
+
+@pytest.mark.parametrize(
+    'typestr, expected_parse',
+    (
+        ('uint256', ('uint', '256', [])),
+        ('uint', ('uint', '256', [])),
+        ('function', ('bytes', '24', [])),
+    )
+)
+def test_process_type(typestr, expected_parse):
+    assert process_type(typestr) == expected_parse


### PR DESCRIPTION
If accepted, this can close the open PR #12 and https://github.com/pipermerriam/web3.py/issues/164 in a single shot.

The basic idea is that since `function` is ["equivalent to"](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#types) `bytes24`, we can reuse all the encoding/decoding/testing already in place for `bytes` types.

Thoughts?