### PR TITLE
Verify fixed-point decimal types

### DIFF
--- a/eth_abi/utils/parsing.py
+++ b/eth_abi/utils/parsing.py
@@ -37,6 +37,17 @@ def process_strict_type(typ):
             raise ValueError("Integer size out of bounds")
         if int(sub) % 8 != 0:
             raise ValueError("Integer size must be multiple of 8")
+    # Check validity of fixed type
+    elif base == 'ufixed' or base == 'fixed':
+        if not re.match('^[0-9]+x[0-9]+$', sub):
+            raise ValueError("Fixed type must have suffix of form <high>x<low>, eg. 128x128")
+        bits, minus_e = [int(x) for x in sub.split('x')]
+        if bits % 8 != 0:
+            raise ValueError("Fixed size must be multiple of 8")
+        if bits < 8 or bits > 256:
+            raise ValueError("Fixed size out of bounds (max 256 bits)")
+        if minus_e < 1 or minus_e > 80:
+            raise ValueError("Fixed size exponent is out of bounds, %s must be in 1-80" % minus_e)
     # Check validity of real type
     elif base == 'ureal' or base == 'real':
         if not re.match('^[0-9]+x[0-9]+$', sub):

--- a/tests/utility/test_parsing.py
+++ b/tests/utility/test_parsing.py
@@ -16,3 +16,23 @@ from eth_abi.utils.parsing import (
 )
 def test_process_type(typestr, expected_parse):
     assert process_type(typestr) == expected_parse
+
+
+@pytest.mark.parametrize(
+    'typestr',
+    (
+        ('fixed0x1'),
+        ('fixed264x1'),
+        ('fixed9x1'),
+        ('fixed256x0'),
+        ('fixed256x81'),
+        ('ufixed0x1'),
+        ('ufixed264x1'),
+        ('ufixed9x1'),
+        ('ufixed256x0'),
+        ('ufixed256x81'),
+    )
+)
+def test_process_exceptions(typestr):
+    with pytest.raises(ValueError):
+        process_type(typestr)


### PR DESCRIPTION
Added the fixed type described here: https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI#types