### PR TITLE
process_type can handle bytes types again

### DIFF
--- a/eth_abi/abi.py
+++ b/eth_abi/abi.py
@@ -21,8 +21,9 @@ from eth_abi.encoding import (
     get_multi_encoder,
 )
 
-from eth_abi.utils.parsing import (
+from eth_abi.utils.parsing import (  # noqa: F401
     process_type,
+    collapse_type,
 )
 
 

--- a/eth_abi/utils/parsing.py
+++ b/eth_abi/utils/parsing.py
@@ -3,7 +3,7 @@ import re
 import string
 
 from eth_utils import (
-    force_text,
+    coerce_args_to_text,
 )
 
 DEFAULT_LENGTHS = (
@@ -14,9 +14,14 @@ DEFAULT_LENGTHS = (
 )
 
 
+@coerce_args_to_text
 def process_type(raw_type):
     typ = normalize_type(raw_type)
     return process_strict_type(typ)
+
+
+def collapse_type(base, sub, arrlist):
+    return str(base + sub + ''.join(map(repr, arrlist)))
 
 
 def normalize_type(raw_type):
@@ -32,7 +37,7 @@ def process_strict_type(typ):
     # Crazy reg expression to separate out base type component (eg. uint),
     # size (eg. 256, 128x128, none), array component (eg. [], [45], none)
     regexp = '([a-z]*)([0-9]*x?[0-9]*)((\[[0-9]*\])*)'
-    base, sub, arr, _ = re.match(regexp, force_text(typ)).groups()
+    base, sub, arr, _ = re.match(regexp, typ).groups()
     arrlist = re.findall('\[[0-9]*\]', arr)
     if len(''.join(arrlist)) != len(arr):
         raise ValueError("Unknown characters found in array declaration")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+flake8==3.*
 pytest>=3.0.3
 pytest-pythonpath>=0.7.1
 tox>=2.4.1

--- a/tests/utility/test_parsing.py
+++ b/tests/utility/test_parsing.py
@@ -2,6 +2,7 @@
 import pytest
 
 from eth_abi.utils.parsing import (
+    collapse_type,
     process_type,
 )
 
@@ -9,6 +10,7 @@ from eth_abi.utils.parsing import (
 @pytest.mark.parametrize(
     'typestr, expected_parse',
     (
+        (b'uint256', ('uint', '256', [])),
         ('uint256', ('uint', '256', [])),
         ('uint', ('uint', '256', [])),
         ('uint256[]', ('uint', '256', [[]])),
@@ -41,3 +43,20 @@ def test_process_type(typestr, expected_parse):
 def test_process_exceptions(typestr):
     with pytest.raises(ValueError):
         process_type(typestr)
+
+
+@pytest.mark.parametrize(
+    'original, expected',
+    [
+        ('address', 'address'),
+        ('uint[2][]', 'uint256[2][]'),
+        ('uint256[2][]', 'uint256[2][]'),
+        ('function', 'bytes24'),
+        ('bool', 'bool'),
+        ('bytes32', 'bytes32'),
+        ('bytes', 'bytes'),
+        ('string', 'string'),
+    ],
+)
+def test_collapse_type(original, expected):
+    assert collapse_type(*process_type(original)) == expected


### PR DESCRIPTION
`process_type()` used to support `raw_type` passed as `bytes`, but the new normalization did not support it.

This adds a test and readds support.