### PR TITLE
showcase signed int decoder failure

### DIFF
--- a/tests/decoding/test_single_decoders.py
+++ b/tests/decoding/test_single_decoders.py
@@ -108,6 +108,7 @@ def test_decode_unsigned_int(integer_bit_size, stream_bytes, data_byte_size):
     stream_bytes=st.binary(min_size=0, max_size=32, average_size=32),
     data_byte_size=st.integers(min_value=0, max_value=32),
 )
+@example(8, b'\x00\x80', 2)
 def test_decode_signed_int(integer_bit_size, stream_bytes, data_byte_size):
     if integer_bit_size % 8 != 0:
         with pytest.raises(ValueError):

--- a/tests/decoding/test_single_decoders.py
+++ b/tests/decoding/test_single_decoders.py
@@ -139,11 +139,16 @@ def test_decode_signed_int(integer_bit_size, stream_bytes, data_byte_size):
     else:
         actual_value = raw_value
 
+    padding_bytes = data_byte_size - integer_bit_size // 8
+
     if len(stream_bytes) < data_byte_size:
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
-    elif raw_value > 2 ** integer_bit_size - 1:
+    elif (
+        raw_value > 2 ** integer_bit_size - 1 or
+        (actual_value < 0 and any(byte < 255 for byte in stream_bytes[:padding_bytes]))
+    ):
         with pytest.raises(NonEmptyPaddingBytes):
             decoder(stream)
         return


### PR DESCRIPTION
The decoder implementation seems to expect `FF` padding instead of `00` padding on a negative integer. I don't know the details well enough here to fix this. (Not sure whether the test setup or implementation is wrong)

Apparently the failure has been there all along, but hypothesis just found it. I only added the new failing example in this PR to highlight it.

![shrug](http://barkpost-assets.s3.amazonaws.com/wp-content/uploads/2013/10/111.jpg)