### PR TITLE
Do not warn about hex input on b''

### DIFF
--- a/eth_abi/abi.py
+++ b/eth_abi/abi.py
@@ -50,6 +50,8 @@ HEX_CHARS = b'1234567890abcdef'
 
 
 def is_hex_encoded_value(v):
+    if v == b'':
+        return False
     if not remove_0x_prefix(force_bytes(v)).lower().strip(HEX_CHARS) == b'':
         return False
     if len(remove_0x_prefix(v)) % 64 and len(remove_0x_prefix(v)) % 40:


### PR DESCRIPTION
### What was wrong?

`decode_abi` was warning about receiving hex data if it was passed data `b''`

### How was it fixed?

Explicity recognize `b''` as not hex.

#### Cute Animal Picture

![Cute animal picture](http://static2.businessinsider.com/image/5798c236dd08951f538b490f/youve-never-heard-an-animal-sound-as-weird-as-this-baby-panda.jpg)
