### PR TITLE
upgrade to eth-utils v1, drop py2, decimal fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info
 dist
 build
+.eggs
 eggs
 parts
 bin
@@ -27,6 +28,7 @@ pip-log.txt
 .tox
 nosetests.xml
 .cache
+.pytest_cache
 
 # Translations
 *.mo
@@ -45,3 +47,6 @@ docs/_build
 
 # Hypothesis
 .hypothesis
+
+# Editors
+.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
   - "3.5"
-env:
-  matrix:
-    - TOX_ENV=py27
-    - TOX_ENV=py34
-    - TOX_ENV=py35
-    - TOX_ENV=flake8
+matrix:
+  include:
+  - env: TOX_ENV=flake8
+  - env: TOX_ENV=py35
+  - env: TOX_ENV=py36
+    python: "3.6"
 cache: pip
 install:
   - "travis_retry pip install setuptools --upgrade"

--- a/eth_abi/utils/numeric.py
+++ b/eth_abi/utils/numeric.py
@@ -85,10 +85,12 @@ def compute_signed_real_bounds(num_high_bits, num_low_bits):
 
 
 def quantize_value(value, decimal_bit_size):
-        num_decimals = int(math.ceil(math.log10(2 ** decimal_bit_size)))
+    num_decimals = int(math.ceil(math.log10(2 ** decimal_bit_size)))
+    with decimal.localcontext() as ctx:
+        ctx.prec = 999
         if num_decimals == 0:
-            quantize_value = decimal.Decimal('1')
+            quantize_value = decimal.Decimal('1', context=ctx)
         else:
-            quantize_value = decimal.Decimal('1.{0}'.format(''.zfill(num_decimals)))
-        decimal_value = decimal.Decimal(value)
-        return decimal_value.quantize(quantize_value)
+            quantize_value = decimal.Decimal('1.{0}'.format(''.zfill(num_decimals)), context=ctx)
+        decimal_value = decimal.Decimal(value, context=ctx)
+        return decimal_value.quantize(quantize_value, context=ctx)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/ethereum/eth-abi',
     include_package_data=True,
     install_requires=[
-        'eth-utils==0.7.*',
+        'eth-utils>=1.0.0b1,<2.0.0',
     ],
     setup_requires=['setuptools-markdown'],
     py_modules=['eth_abi'],
@@ -30,10 +30,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist=
-    py27,
-    py34,
     py35,
+    py36,
     flake8
 
 [flake8]
@@ -13,17 +12,12 @@ exclude= tests/*
 commands=py.test --tb native {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
-
-[testenv:py27]
-basepython=python2.7
-
-[testenv:py34]
-basepython=python3.4
-
-[testenv:py35]
-basepython=python3.5
+basepython=
+  py34: python3.4
+  py35: python3.5
+  py36: python3.6
 
 [testenv:flake8]
 basepython=python
 deps=flake8
-commands=flake8 {toxinidir}/eth_abi
+commands=flake8 {toxinidir}/eth_abi {toxinidir}/tests


### PR DESCRIPTION
eth-utils used to modify the global decimal context, to precision 999
but that went away in v1. eth-abi was depending on that
global change, so now 999 precision has to be set locally.

### What was wrong?

#25 

### How was it fixed?

upgrade eth-utils to v1, fix a decimal dependency that changed.

#### Cute Animal Picture

![Cute animal picture](https://www.luvbat.com/uploads/cute_turtle_hatching_2547267586.jpg)