### PR TITLE
Carver/low precision decimal test

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -13,6 +13,7 @@ from eth_abi.exceptions import (
     NonEmptyPaddingBytes,
 )
 from eth_abi.utils.numeric import (
+    abi_decimal_context,
     big_endian_to_int,
     quantize_value,
     ceil32,
@@ -386,9 +387,10 @@ class UnsignedRealDecoder(BaseRealDecoder):
     @classmethod
     def decoder_fn(cls, data):
         value = big_endian_to_int(data)
-        decimal_value = decimal.Decimal(value)
-        raw_real_value = decimal_value / 2 ** cls.low_bit_size
-        real_value = quantize_value(raw_real_value, cls.low_bit_size)
+        with decimal.localcontext(abi_decimal_context):
+            decimal_value = decimal.Decimal(value)
+            raw_real_value = decimal_value / 2 ** cls.low_bit_size
+            real_value = quantize_value(raw_real_value, cls.low_bit_size)
         return real_value
 
 

--- a/eth_abi/utils/numeric.py
+++ b/eth_abi/utils/numeric.py
@@ -39,6 +39,9 @@ else:
         return int.from_bytes(value, byteorder='big')
 
 
+abi_decimal_context = decimal.Context(prec=999)
+
+
 def ceil32(x):
     return x if x % 32 == 0 else x + 32 - (x % 32)
 
@@ -86,8 +89,7 @@ def compute_signed_real_bounds(num_high_bits, num_low_bits):
 
 def quantize_value(value, decimal_bit_size):
     num_decimals = int(math.ceil(math.log10(2 ** decimal_bit_size)))
-    with decimal.localcontext() as ctx:
-        ctx.prec = 999
+    with decimal.localcontext(abi_decimal_context):
         if num_decimals == 0:
             quantize_value = decimal.Decimal('1')
         else:

--- a/eth_abi/utils/numeric.py
+++ b/eth_abi/utils/numeric.py
@@ -89,8 +89,8 @@ def quantize_value(value, decimal_bit_size):
     with decimal.localcontext() as ctx:
         ctx.prec = 999
         if num_decimals == 0:
-            quantize_value = decimal.Decimal('1', context=ctx)
+            quantize_value = decimal.Decimal('1')
         else:
-            quantize_value = decimal.Decimal('1.{0}'.format(''.zfill(num_decimals)), context=ctx)
-        decimal_value = decimal.Decimal(value, context=ctx)
-        return decimal_value.quantize(quantize_value, context=ctx)
+            quantize_value = decimal.Decimal('1.{0}'.format(''.zfill(num_decimals)))
+        decimal_value = decimal.Decimal(value)
+        return decimal_value.quantize(quantize_value)

--- a/tests/decoding/test_single_decoders.py
+++ b/tests/decoding/test_single_decoders.py
@@ -46,6 +46,7 @@ from eth_abi.utils.padding import (
     zpad32,
 )
 from eth_abi.utils.numeric import (
+    abi_decimal_context,
     big_endian_to_int,
     int_to_big_endian,
     compute_signed_integer_bounds,
@@ -416,7 +417,10 @@ def test_decode_unsigned_real(high_bit_size,
         decoded_value = decoder(stream)
 
     unsigned_integer_value = big_endian_to_int(stream_bytes[:data_byte_size])
-    raw_real_value = decimal.Decimal(unsigned_integer_value) / 2 ** low_bit_size
+
+    with decimal.localcontext(abi_decimal_context):
+        raw_real_value = decimal.Decimal(unsigned_integer_value) / 2 ** low_bit_size
+
     actual_value = quantize_value(raw_real_value, low_bit_size)
 
     assert decoded_value == actual_value
@@ -483,7 +487,9 @@ def test_decode_signed_real(high_bit_size,
     else:
         signed_integer_value = unsigned_integer_value
 
-    raw_actual_value = decimal.Decimal(signed_integer_value) / 2 ** low_bit_size
+    with decimal.localcontext(abi_decimal_context):
+        raw_actual_value = decimal.Decimal(signed_integer_value) / 2 ** low_bit_size
+
     actual_value = quantize_value(raw_actual_value, low_bit_size)
 
     assert decoded_value == actual_value

--- a/tests/encoding/test_single_encoders.py
+++ b/tests/encoding/test_single_encoders.py
@@ -287,6 +287,13 @@ def test_encode_string(string_value):
     value_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     data_byte_size=st.integers(min_value=1, max_value=32),
 )
+@example(
+    base_integer_value=384,
+    value_bit_size=232,
+    high_bit_size=64,
+    low_bit_size=168,
+    data_byte_size=29,
+)
 def test_encode_unsigned_real(base_integer_value,
                               value_bit_size,
                               high_bit_size,
@@ -324,7 +331,10 @@ def test_encode_unsigned_real(base_integer_value,
         assert 'UnsignedReal' in str(exception_info.value)
         return
 
-    real_value = decimal.Decimal(base_integer_value) / 2 ** low_bit_size
+    with decimal.localcontext() as ctx:
+        ctx.prec = 999
+        real_value = decimal.Decimal(base_integer_value) / 2 ** low_bit_size
+
     lower_bound, upper_bound = compute_unsigned_real_bounds(
         high_bit_size,
         low_bit_size,

--- a/tests/encoding/test_single_encoders.py
+++ b/tests/encoding/test_single_encoders.py
@@ -41,6 +41,7 @@ from eth_abi.encoding import (
 )
 
 from eth_abi.utils.numeric import (
+    abi_decimal_context,
     int_to_big_endian,
     compute_unsigned_integer_bounds,
     compute_signed_integer_bounds,
@@ -331,8 +332,7 @@ def test_encode_unsigned_real(base_integer_value,
         assert 'UnsignedReal' in str(exception_info.value)
         return
 
-    with decimal.localcontext() as ctx:
-        ctx.prec = 999
+    with decimal.localcontext(abi_decimal_context):
         real_value = decimal.Decimal(base_integer_value) / 2 ** low_bit_size
 
     lower_bound, upper_bound = compute_unsigned_real_bounds(
@@ -397,7 +397,10 @@ def test_encode_signed_real(base_integer_value,
         return
 
     unsigned_integer_value = base_integer_value % 2**(high_bit_size + low_bit_size)
-    real_value = decimal.Decimal(unsigned_integer_value) / 2 ** low_bit_size
+
+    with decimal.localcontext(abi_decimal_context):
+        real_value = decimal.Decimal(unsigned_integer_value) / 2 ** low_bit_size
+
     lower_bound, upper_bound = compute_signed_real_bounds(
         high_bit_size,
         low_bit_size,


### PR DESCRIPTION
### What was wrong?

A version bump failed, that's weird:
https://travis-ci.org/ethereum/eth-abi/jobs/337782324 

Even weirder, a travis test on the same commit succeeded:
https://travis-ci.org/ethereum/eth-abi/jobs/337782341

Oh, it's a hypothesis test, so we had to get lucky on finding the example. Turns out the failure was related to building the expected value in the test, not in the project source.

### How was it fixed?

- add the failing example to make sure the case is always covered
- set precision higher when building expected value
- too many magic numbers: moved to centralized `decimal.Context` definition
- grep'd for all `Decimal` usages to put them in the `abi_decimal_context`

#### Cute Animal Picture

![Cute animal picture](https://i.ytimg.com/vi/QXtC0jOVZNs/hqdefault.jpg)