### PR TITLE
Housekeeping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,58 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: lint
+  py35:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35
+  py36:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36
+  pypy3:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3
+workflows:
+  version: 2
+  test:
+    jobs:
+      - lint
+      - py35
+      - py36
+      - pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ python:
   - "3.5"
 matrix:
   include:
-    - python: "3.4"
-      env: TOX_ENV=py34
     - python: "3.5"
       env: TOX_ENV=py35
     - python: "3.6"
       env: TOX_ENV=py36
+    - python: "pypy3.5"
+      env: TOX_ENV=pypy3
     - python: "3.5"
       env: TOX_ENV=flake8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - python: "pypy3.5"
       env: TOX_ENV=pypy3
     - python: "3.5"
-      env: TOX_ENV=flake8
+      env: TOX_ENV=lint
 cache:
   pip: true
 install:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ release: clean
 	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true
 	bumpversion $(bump)
-	git push && git push --tags
+	git push upstream && git push upstream --tags
 	python setup.py sdist bdist_wheel upload
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0
+-------------
+
+Released Feb 28, 2018
+
+- Confirmed pypy3 compatibility
+- Add support for eth-utils v1.0.0-beta2 and v1.0.1 stable
+- Testing improvements
+
 v1.0.0-beta.0
 -------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,4 @@ pytest-pythonpath>=0.7.1
 tox>=2.4.1
 hypothesis>=3.6.1
 bumpversion==0.5.3
-eth-hash[pycryptodome]>=0.1.0a2,<1.0.0
+eth-hash[pycryptodome]>=0.1.0,<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url='https://github.com/ethereum/eth-abi',
     include_package_data=True,
     install_requires=[
-        'eth-utils>=1.0.0b2,<2.0.0',
+        'eth-utils>=1.0.1,<2.0.0',
     ],
     extras_require={
         'doc': [

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,13 @@ setup(
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist=
-    py34,
-    py35,
-    py36,
+    py{35,36,py3},
     flake8
 
 [flake8]
@@ -14,9 +12,9 @@ commands=py.test --tb native {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
 basepython=
-  py34: python3.4
   py35: python3.5
   py36: python3.6
+  pypy3: pypy3
 
 [testenv:flake8]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{35,36,py3},
-    flake8
+    lint
 
 [flake8]
 max-line-length= 100
@@ -16,7 +16,7 @@ basepython=
   py36: python3.6
   pypy3: pypy3
 
-[testenv:flake8]
+[testenv:lint]
 basepython=python
 deps=flake8
 commands=flake8 {toxinidir}/eth_abi {toxinidir}/tests


### PR DESCRIPTION
### What was wrong?

- no circleci tests
- no pypy3 tests
- depended on beta eth-utils version
- depended on alpha eth-hash
- releases were going to origin or default push repo

### How was it fixed?

The straightforward way

Also, dropped py3.4 support.

#### Cute Animal Picture

![Cute animal picture](https://d2pu2bk1b66iw6.cloudfront.net/photos/2017/08/01/6-172370-cute-adult-koala-from-australia-sleeping-on-tree-1501596756.jpg)
