### PR TITLE
Fix typos in exception messages

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -80,9 +80,12 @@ class BaseDecoder(object):
         for key in kwargs:
             if not hasattr(cls, key):
                 raise AttributeError(
-                    "Property {0} not found on Decoder class. "
-                    "`Decoder.factory` only accepts keyword arguments which are "
-                    "present on the Decoder class".format(key)
+                    "Property `{key}` not found on {cls_name} class. "
+                    "`{cls_name}.as_decoder` only accepts keyword arguments which are "
+                    "present on the {cls_name} class.".format(
+                        key=key,
+                        cls_name=cls.__name__,
+                    )
                 )
         if name is None:
             name = cls.__name__

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -94,9 +94,12 @@ class BaseEncoder(object):
         for key in kwargs:
             if not hasattr(cls, key):
                 raise AttributeError(
-                    "Property {0} not found on Decoder class. "
-                    "`Decoder.factory` only accepts keyword arguments which are "
-                    "present on the Decoder class".format(key)
+                    "Property `{key}` not found on {cls_name} class. "
+                    "`{cls_name}.as_encoder` only accepts keyword arguments which are "
+                    "present on the {cls_name} class.".format(
+                        key=key,
+                        cls_name=cls.__name__,
+                    )
                 )
         if name is None:
             name = cls.__name__


### PR DESCRIPTION
### What was wrong?

Some exception messages contained typos.

### How was it fixed?

Fixed the typos.

#### Cute Animal Picture

![Cute animal picture](http://www.yugopolis.ru/media/cache/news2x/data/img/14ee1ae1d27582095bd445d576721e46/228074.jpg)
