### PR TITLE
Experimental (crazy) approach to allowing extensible parsing

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,0 +1,117 @@
+import parsimonious
+
+
+user_types = r"""
+user_types = ""+
+"""[1:-1]
+
+
+parser = parsimonious.Grammar(r"""
+type = tuple_type / basic_type / user_types
+
+{user_types}
+
+tuple_type = "(" type next_type* ")"
+next_type = "," type
+
+basic_type = base sub? arrlist?
+
+base = alphas
+
+sub = (digits "x" digits) / digits
+
+arrlist = (const_arr / dynam_arr)+
+const_arr = "[" digits "]"
+dynam_arr = "[]"
+
+alphas = ~"[a-z]+"
+digits = ~"[0-9]+"
+""".format(user_types=user_types))
+
+
+class ABIType:
+    expr_name = None
+
+    @classmethod
+    def from_string(cls, type_str):
+        return cls.from_node(parser.parse(type_str))
+
+    @staticmethod
+    def from_node(node):
+        if node.expr_name == 'type':
+            return ABIType.from_node(node.children[0])
+
+        for klass in reversed(ABIType.__subclasses__()):
+            if node.expr_name == klass.expr_name:
+                return klass.from_node(node)
+
+        raise ValueError('Unexpected node "{}" encountered'.format(node.expr_name))
+
+    def __repr__(self):
+        cls = type(self)
+
+        return '<{}.{} "{}">'.format(
+            cls.__module__,
+            cls.__qualname__,
+            str(self),
+        )
+
+
+class Tuple(ABIType):
+    expr_name = 'tuple_type'
+
+    def __init__(self, node, components):
+        self.node = node
+
+        self.components = components
+
+    def __str__(self):
+        return '({})'.format(
+            ','.join(str(c) for c in self.components),
+        )
+
+    def __getitem__(self, key):
+        return self.components[key]
+
+    @classmethod
+    def from_node(cls, node):
+        from_node_ = super().from_node
+
+        left_paren, first, rest, right_paren = node
+
+        components = [from_node_(first)]
+        for comma, abi_type in rest.children:
+            components.append(from_node_(abi_type))
+
+        return cls(components)
+
+
+class Basic(ABIType):
+    expr_name = 'basic_type'
+
+    def __init__(self, node, base, sub, arrlist):
+        self.node = node
+
+        self.base = base
+        self.sub = sub
+        self.arrlist = arrlist
+
+    def __str__(self):
+        return '{}{}{}'.format(
+            self.base.text,
+            self.sub.text,
+            self.arrlist.text,
+        )
+
+    @classmethod
+    def from_node(cls, node):
+        base, sub, arrlist = node
+
+        return cls(node, base, sub, arrlist)
+
+
+uint = ABIType.from_string('uint')
+uint256 = ABIType.from_string('uint256')
+fixed128x19 = ABIType.from_string('fixed128x19')
+tup = ABIType.from_string('(uint,bool,fixed128x19)')
+nested_tup = ABIType.from_string('(uint,bool,(fixed,address))')


### PR DESCRIPTION
Just some ideas for how we could implement extensible parsing.

### What was wrong?

Was trying to figure out interesting methods of extensibility for the eth-abi library.

### How was it fixed?

Added a parser defined with `parsimonious` library and included the beginnings of some functionality for extending that parser.

It might be possible to allow users to define their own parsing rules for types which can't be parsed with our default grammar.  They could then create a subclass of `ABIType` to handle the processing of parse results for those rules.  The `ABIType.from_node` static method iterates through all subclasses of `ABIType` (the ordering, I believe, goes from most recently defined to least recently defined) to find one which can handle the parsing results for a certain rule (identified by the `expr_name` property on a parsimonious parse node).  `ABIType` subclasses indicate their associated grammar rule via the `expr_name` class property.  They must implement `from_node` as a class method in order to produce an instance of themselves according to the results of their associated parse rule.

#### Cute Animal Picture

![Cute animal picture](https://www.zoo.org.au/sites/default/files/styles/zv_carousel_large/public/platypus-dry-animal-profile-web620.jpg)
