### PR TITLE
Fix abi_type_strategies.sized_list_strats

### DIFF
--- a/tests/property/abi_type_strategies.py
+++ b/tests/property/abi_type_strategies.py
@@ -84,12 +84,12 @@ sized_list_strats = [
     st.tuples(
         st.shared(
             st.integers(min_value=MIN_LIST_SIZE, max_value=MAX_LIST_SIZE),
-            key="n",
-        ).map(lambda n: type_str + "[{0}]".format(n)),
+            key="sized_list_strats",
+        ).map(lambda n, type_str=type_str: type_str + "[{0}]".format(n)),
         st.shared(
             st.integers(min_value=MIN_LIST_SIZE, max_value=MAX_LIST_SIZE),
-            key="n",
-        ).flatmap(lambda n: st.lists(type_strat, min_size=n, max_size=n).map(tuple))
+            key="sized_list_strats",
+        ).flatmap(lambda n, type_strat=type_strat: st.lists(type_strat, min_size=n, max_size=n).map(tuple))
     ) for type_str, type_strat in all_basic_raw_strats
 ]
 


### PR DESCRIPTION
### What was wrong?

The values of `type_str` and `type_strat` are not determined until the lambdas are evaluated. 
Therefore, every resulting lambda references the values in the last tuple in `all_basic_raw_strats` which happen to be for address sampling.

This causes the resulting strategy to only generate *address* lists instead of a list for any possible type in `all_basic_raw_strats`.

Also, the shared value key should probably be more unique.

### How was it fixed?

Said values are now explicitly captured in lambdas.  Also changed shared value key.

#### Cute Animal Picture

![Cute animal picture](https://pbs.twimg.com/media/CxLEDgKWEAAHalr.jpg:large)
