### PR TITLE
Fix residue truncation by fixed encoders

### DIFF
--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -296,6 +296,24 @@ class BaseFixedEncoder(NumberEncoder):
         return False
 
     @classmethod
+    def validate_value(cls, value):
+        super().validate_value(value)
+
+        with decimal.localcontext(abi_decimal_context):
+            residue = value % (TEN ** -cls.frac_places)
+
+        if residue > 0:
+            raise ValueError(
+                '{} cannot encode value {}: '
+                'residue {} outside allowed fractional precision of {}'.format(
+                    cls.__name__,
+                    repr(value),
+                    repr(residue),
+                    cls.frac_places,
+                )
+            )
+
+    @classmethod
     def validate(cls):
         super().validate()
 


### PR DESCRIPTION
### What was wrong?

Current implementation of fixed encoders silently truncates residue in decimal value which is outside of given precision:
```python
In [1]: from eth_abi import encode_single, decode_single

In [2]: from decimal import Decimal

In [3]: v = Decimal('0.33')

In [4]: decode_single('ufixed8x1', encode_single('ufixed8x1', v))
Out[4]: Decimal('0.3')
```

### How was it fixed?

Explicitly check for decimal residue according to the fractional places of a fixed encoder.

#### Cute Animal Picture

![Cute animal picture](https://hir.ma/wp-content/uploads/2014/05/dolphinspeaker-300x168.jpg)
