### PR TITLE
Make Circle CI config less org-specific

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ common: &common
             # We need these config values or git complains when creating the
             # merge commit
             git config --global user.name "Circle CI"
-            git config --global user.email "circleci@ethereum.org"
+            git config --global user.email "circleci@example.com"
 
             git merge --no-edit circleci/pr-base
           fi


### PR DESCRIPTION
### What was wrong?

Circle CI config shouldn't necessarily reference a fake ethereum.org address.

### How was it fixed?

Changed it.

#### Cute Animal Picture

![Cute animal picture](https://mmehappy.com/wp-content/uploads/2017/11/17-cute-animal-pics-for-your-wednesday-love-cute-animals.jpg)
