### PR TITLE
Fix parse type str

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+htmlcov/
 .tox
 nosetests.xml
 .cache

--- a/eth_abi/base.py
+++ b/eth_abi/base.py
@@ -51,7 +51,6 @@ def parse_type_str(expected_base=None, with_arrlist=False):
                     'no array dimension list'.format(
                         cls.__name__,
                         type_str_repr,
-                        expected_base,
                     )
                 )
             if with_arrlist and abi_type.arrlist is None:
@@ -60,7 +59,6 @@ def parse_type_str(expected_base=None, with_arrlist=False):
                     'array dimension list'.format(
                         cls.__name__,
                         type_str_repr,
-                        expected_base,
                     )
                 )
 

--- a/tests/base/test_base.py
+++ b/tests/base/test_base.py
@@ -1,0 +1,106 @@
+import pytest
+
+
+from eth_abi.base import (
+    BaseCoder,
+    parse_type_str,
+)
+
+
+class Coder(BaseCoder):
+    base = None
+    sub = None
+
+    def validate(self):
+        if self.base is None:
+            raise ValueError('Setting missing')
+
+    @parse_type_str(with_arrlist=False)
+    def from_type_str(cls, abi_type, registry):
+        return cls(base=abi_type.base, sub=abi_type.sub)
+
+
+class ArrayCoder(Coder):
+    arrlist = None
+
+    @parse_type_str(with_arrlist=True)
+    def from_type_str(cls, abi_type, registry):
+        return cls(base=abi_type.base, sub=abi_type.sub, arrlist=abi_type.arrlist)
+
+
+class IntCoder(Coder):
+    @parse_type_str('int', with_arrlist=False)
+    def from_type_str(cls, abi_type, registry):
+        return cls(base=abi_type.base, sub=abi_type.sub)
+
+
+class IntArrayCoder(ArrayCoder):
+    @parse_type_str('int', with_arrlist=True)
+    def from_type_str(cls, abi_type, registry):
+        return cls(base=abi_type.base, sub=abi_type.sub, arrlist=abi_type.arrlist)
+
+
+def test_base_coder_requires_that_settings_are_known():
+    pattern = 'only accepts keyword arguments which are present'
+    with pytest.raises(AttributeError, match=pattern):
+        coder = Coder(foo='bar')
+
+
+def test_base_coder_validates_settings():
+    with pytest.raises(ValueError, match='Setting missing'):
+        coder = Coder(sub='foo')
+
+
+def test_base_coder_assigns_all_kwargs_to_instance():
+    coder = Coder(base='foo', sub='bar')
+
+    assert coder.base == 'foo'
+    assert coder.sub == 'bar'
+
+
+def test_parse_type_str_normalizes_and_parses_types():
+    coder1 = Coder.from_type_str('int', None)
+
+    assert coder1.base == 'int'
+    assert coder1.sub == 256
+
+
+def test_parse_type_str_validates_standard_types():
+    with pytest.raises(ValueError, match='integer size must be multiple of 8'):
+        Coder.from_type_str('int255', None)
+
+
+def test_parse_type_str_distinguishes_non_tuple_and_tuple_types():
+    with pytest.raises(ValueError, match='Cannot create Coder for non-basic type'):
+        Coder.from_type_str('(int256,bool)', None)
+
+
+def test_parse_type_str_requires_certain_base_type_if_given():
+    with pytest.raises(ValueError, match='expected type with base \'int\''):
+        IntCoder.from_type_str('uint256', None)
+
+    with pytest.raises(ValueError, match='expected type with base \'int\''):
+        IntArrayCoder.from_type_str('uint256[]', None)
+
+
+def test_parse_type_str_doesnt_require_base_type_if_not_given():
+    coder1 = Coder.from_type_str('uint256', None)
+    assert coder1.base == 'uint'
+    assert coder1.sub == 256
+
+    coder2 = ArrayCoder.from_type_str('uint256[]', None)
+    assert coder2.base == 'uint'
+    assert coder2.sub == 256
+    assert coder2.arrlist == ((),)
+
+
+def test_parse_type_str_distinguishes_non_array_and_array_types():
+    with pytest.raises(ValueError, match='expected type with no array dimension list'):
+        Coder.from_type_str('int256[]', None)
+    with pytest.raises(ValueError, match='expected type with array dimension list'):
+        ArrayCoder.from_type_str('int256', None)
+
+    with pytest.raises(ValueError, match='expected type with no array dimension list'):
+        IntCoder.from_type_str('int256[]', None)
+    with pytest.raises(ValueError, match='expected type with array dimension list'):
+        IntArrayCoder.from_type_str('int256', None)


### PR DESCRIPTION
### What was wrong?

There were some unused format arguments in `parse_type_str`.  Also, the `base.py` module lacked a testing module which specifically targets it.

### How was it fixed?

Removed unused format arguments.  Also added `test_base.py` module.

#### Cute Animal Picture

![Cute animal picture](https://fthmb.tqn.com/qq1JpR79gtTFbEmR44cCXf10eGU=/768x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/monkey-funny-face-58b8ed643df78c353c312c09.jpg)
