### PR TITLE
String type can't have length

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -263,12 +263,17 @@ class BasicType(ABIType):
         base, sub = self.base, self.sub
 
         # Check validity of string type
-        if base in ('string', 'bytes'):
+        if base == 'string':
+            if sub is not None:
+                self.invalidate('string type cannot have suffix')
+
+        # Check validity of bytes type
+        elif base == 'bytes':
             if not (sub is None or isinstance(sub, int)):
-                self.invalidate('string type must have either no suffix or a numerical suffix')
+                self.invalidate('bytes type must have either no suffix or a numerical suffix')
 
             if isinstance(sub, int) and sub > 32:
-                self.invalidate('maximum 32 bytes for fixed-length string or bytes')
+                self.invalidate('maximum 32 bytes for fixed-length bytes')
 
         # Check validity of integer type
         elif base in ('int', 'uint'):

--- a/tests/utility/test_grammar.py
+++ b/tests/utility/test_grammar.py
@@ -111,8 +111,8 @@ def test_end_to_end_parsing_and_collapsing(type_str):
 @pytest.mark.parametrize(
     'type_str, pattern',
     (
-        ('string1x1', 'no suffix or a numerical'),
-        ('string33', 'maximum 32 bytes'),
+        ('string1x1', 'string type cannot have suffix'),
+        ('string33', 'string type cannot have suffix'),
         ('bytes1x1', 'no suffix or a numerical'),
         ('bytes33', 'maximum 32 bytes'),
         ('int', 'must have numerical suffix'),


### PR DESCRIPTION
### What was wrong?

String types were incorrectly validated for numerical sub types.

### How was it fixed?

String types now may not have a sub type.

#### Cute Animal Picture

![Cute animal picture](https://images.duckduckgo.com/iu/?u=https%3A%2F%2F1.bp.blogspot.com%2F-tSdQpPkdqA8%2FWTG35dUf25I%2FAAAAAAABxIk%2FKRAAoYKCC2UMhzSR2YwZNPD0JTwk_oITwCLcB%2Fs1600%2Ffunny-animals-267-01.jpg&f=1)
