### PR TITLE
Remove unused coder instances

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -229,9 +229,6 @@ class BooleanDecoder(Fixed32ByteSizeDecoder):
         return cls()
 
 
-decode_bool = BooleanDecoder()
-
-
 class AddressDecoder(Fixed32ByteSizeDecoder):
     value_bit_size = 20 * 8
     is_big_endian = True
@@ -240,9 +237,6 @@ class AddressDecoder(Fixed32ByteSizeDecoder):
     @parse_type_str('address')
     def from_type_str(cls, abi_type, registry):
         return cls()
-
-
-decode_address = AddressDecoder()
 
 
 #
@@ -485,13 +479,7 @@ class StringDecoder(SingleDecoder):
         return cls()
 
 
-decode_string = StringDecoder()
-
-
 class ByteStringDecoder(StringDecoder):
     @parse_type_str('bytes')
     def from_type_str(cls, abi_type, registry):
         return cls()
-
-
-decode_bytes = ByteStringDecoder()

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -178,9 +178,6 @@ class BooleanEncoder(Fixed32ByteSizeEncoder):
         return cls()
 
 
-encode_bool = BooleanEncoder()
-
-
 class NumberEncoder(Fixed32ByteSizeEncoder):
     is_big_endian = True
     bounds_fn = None
@@ -445,9 +442,6 @@ class AddressEncoder(Fixed32ByteSizeEncoder):
         return cls()
 
 
-encode_address = AddressEncoder()
-
-
 class BytesEncoder(Fixed32ByteSizeEncoder):
     is_big_endian = False
 
@@ -501,9 +495,6 @@ class ByteStringEncoder(BaseEncoder):
         return cls()
 
 
-encode_bytes = ByteStringEncoder()
-
-
 class TextStringEncoder(ByteStringEncoder):
     @classmethod
     def encode(cls, value):
@@ -520,9 +511,6 @@ class TextStringEncoder(ByteStringEncoder):
     @parse_type_str('string')
     def from_type_str(cls, abi_type, registry):
         return cls()
-
-
-encode_string = TextStringEncoder()
 
 
 class BaseArrayEncoder(BaseEncoder):


### PR DESCRIPTION
### What was wrong?

There were some explicit instantiations of coder classes hanging around from before when the registry handled all of that.

### How was it fixed?

Removed them.  The exceptions were `encode_uint_256` and `decode_uint_256` which are still used internally by other coders.

#### Cute Animal Picture

![Cute animal picture](https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fthewowstyle.com%2Fwp-content%2Fuploads%2F2015%2F05%2Fcute-animal-wallpaper.jpg&f=1)
