### PR TITLE
Add abi.is_encodable

### DIFF
--- a/eth_abi/__init__.py
+++ b/eth_abi/__init__.py
@@ -5,6 +5,7 @@ from eth_abi.abi import (  # NOQA
     decode_abi,
     encode_single,
     encode_abi,
+    is_encodable,
 )
 
 

--- a/eth_abi/abi.py
+++ b/eth_abi/abi.py
@@ -10,6 +10,8 @@ from eth_abi.decoding import (
     TupleDecoder,
 )
 
+from eth_abi.exceptions import EncodingError
+
 from eth_abi.encoding import TupleEncoder
 
 from eth_abi.registry import registry
@@ -40,6 +42,26 @@ def encode_abi(types, args):
     encoder = TupleEncoder(encoders=encoders)
 
     return encoder(args)
+
+
+def is_encodable(typ, arg):
+    """
+    Determines if the given python value ``arg`` can be encoded as a value of
+    abi type ``typ``.
+    """
+    if isinstance(typ, str):
+        type_str = typ
+    else:
+        type_str = collapse_type(*typ)
+
+    encoder = registry.get_encoder(type_str)
+
+    try:
+        encoder.validate_value(arg)
+    except EncodingError:
+        return False
+    else:
+        return True
 
 
 # Decodes a single base datum

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -53,12 +53,11 @@ class BaseEncoder(BaseCoder, metaclass=abc.ABCMeta):
         """
         pass
 
+    @abc.abstractmethod
     def validate_value(self, value):
         """
         Determines whether or not the given value can be encoded by this
-        encoder.  Encoder classes can implement validation of values if desired.
-        By default, this method does nothing and an encoder will attempt to
-        encode any value it is given.
+        encoder.
         """
         pass
 

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -522,11 +522,12 @@ class ByteStringEncoder(BaseEncoder):
     def encode(cls, value):
         cls.validate_value(value)
 
-        encoded_size = encode_uint_256(len(value))
         if not value:
             padded_value = b'\x00' * 32
         else:
             padded_value = zpad_right(value, ceil32(len(value)))
+
+        encoded_size = encode_uint_256(len(value))
         encoded_value = encoded_size + padded_value
 
         return encoded_value
@@ -555,11 +556,12 @@ class TextStringEncoder(BaseEncoder):
 
         value_as_bytes = codecs.encode(value, 'utf8')
 
-        encoded_size = encode_uint_256(len(value_as_bytes))
         if not value_as_bytes:
             padded_value = b'\x00' * 32
         else:
             padded_value = zpad_right(value_as_bytes, ceil32(len(value_as_bytes)))
+
+        encoded_size = encode_uint_256(len(value_as_bytes))
         encoded_value = encoded_size + padded_value
 
         return encoded_value

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -25,23 +25,36 @@ def test_is_encodable_returns_true(type_str, python_value, _):
 @pytest.mark.parametrize(
     'type_str,python_value',
     (
-        ('(uint32)', ('6',)),
+        # Expected bool but got int
         ('((bytes,bool),(bytes,bool))', ((b'david attenborough', 0), (b'boaty mcboatface', True))),
-        ('int[]', 6),
+
+        # List size mismatch
         ('int[3]', (6, 2)),
+
+        # Wrong value type
+        ('(uint32)', ('6',)),
+        ('int[]', 6),
         ('bool[2]', (True, 2)),
         ('bool', 1),
         ('uint', True),
         ('int', True),
+
+        # Expected bytes but got int
+        ('bytes', 129),
+
+        # Bytes string is wrong size
+        ('bytes5', b'asdfgt'),
+
+        # Addresses aren't 20 bytes long
+        ('address', '0x8deebe59332ebc3f81935e311f0fb8556cf573'),
+        ('address', decode_hex('0x8deebe59332ebc3f81935e311f0fb8556cf573')),
+
+        # Values out of bounds
         ('uint8', 256),
         ('uint8', -1),
         ('int8', 128),
         ('int8', -129),
         ('string', -129),
-        ('bytes', 129),
-        ('bytes5', b'asdfgt'),
-        ('address', '0x8deebe59332ebc3f81935e311f0fb8556cf573'),
-        ('address', decode_hex('0x8deebe59332ebc3f81935e311f0fb8556cf573')),
         ('fixed8x1', Decimal('128e-1')),
         ('fixed8x1', Decimal('-129e-1')),
         ('ufixed8x1', Decimal('256e-1')),

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -25,22 +25,18 @@ def test_is_encodable_returns_true(type_str, python_value, _):
 @pytest.mark.parametrize(
     'type_str,python_value',
     (
-        # Expected bool but got int
-        ('((bytes,bool),(bytes,bool))', ((b'david attenborough', 0), (b'boaty mcboatface', True))),
-
-        # List size mismatch
-        ('int[3]', (6, 2)),
-
         # Wrong value type
+        ('((bytes,bool),(bytes,bool))', ((b'david attenborough', 0), (b'boaty mcboatface', True))),
         ('(uint32)', ('6',)),
         ('int[]', 6),
         ('bool[2]', (True, 2)),
         ('bool', 1),
         ('uint', True),
         ('int', True),
-
-        # Expected bytes but got int
         ('bytes', 129),
+
+        # List size mismatch
+        ('int[3]', (6, 2)),
 
         # Bytes string is wrong size
         ('bytes5', b'asdfgt'),
@@ -59,6 +55,7 @@ def test_is_encodable_returns_true(type_str, python_value, _):
         ('fixed8x1', Decimal('-129e-1')),
         ('ufixed8x1', Decimal('256e-1')),
         ('ufixed8x1', Decimal('-1e-1')),
+
     )
 )
 def test_is_encodable_returns_false(type_str, python_value):

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 
-from hypothesis import given
+from hypothesis import (
+    given,
+    settings,
+)
 import pytest
 
 from eth_utils import decode_hex
@@ -62,12 +65,14 @@ def test_is_encodable_returns_false(type_str, python_value):
     assert not is_encodable(type_str, python_value)
 
 
+@settings(deadline=300)
 @given(single_strs_values)
 def test_is_encodable_returns_true_for_random_valid_values(type_and_value):
     _type, value = type_and_value
     assert is_encodable(_type, value)
 
 
+@settings(deadline=300)
 @given(tuple_strs_values)
 def test_is_encodable_returns_true_for_random_valid_tuple_values(type_and_value):
     _type, value = type_and_value

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -1,0 +1,64 @@
+from decimal import Decimal
+
+from hypothesis import given
+import pytest
+
+from eth_utils import decode_hex
+
+from eth_abi import is_encodable
+
+from tests.common.strategies import (
+    single_strs_values,
+    tuple_strs_values,
+)
+from tests.common.unit import CORRECT_SINGLE_ENCODINGS
+
+
+@pytest.mark.parametrize(
+    'type_str,python_value,_',
+    CORRECT_SINGLE_ENCODINGS,
+)
+def test_is_encodable_returns_true(type_str, python_value, _):
+    assert is_encodable(type_str, python_value)
+
+
+@pytest.mark.parametrize(
+    'type_str,python_value',
+    (
+        ('(uint32)', ('6',)),
+        ('((bytes,bool),(bytes,bool))', ((b'david attenborough', 0), (b'boaty mcboatface', True))),
+        ('int[]', 6),
+        ('int[3]', (6, 2)),
+        ('bool[2]', (True, 2)),
+        ('bool', 1),
+        ('uint', True),
+        ('int', True),
+        ('uint8', 256),
+        ('uint8', -1),
+        ('int8', 128),
+        ('int8', -129),
+        ('string', -129),
+        ('bytes', 129),
+        ('bytes5', b'asdfgt'),
+        ('address', '0x8deebe59332ebc3f81935e311f0fb8556cf573'),
+        ('address', decode_hex('0x8deebe59332ebc3f81935e311f0fb8556cf573')),
+        ('fixed8x1', Decimal('128e-1')),
+        ('fixed8x1', Decimal('-129e-1')),
+        ('ufixed8x1', Decimal('256e-1')),
+        ('ufixed8x1', Decimal('-1e-1')),
+    )
+)
+def test_is_encodable_returns_false(type_str, python_value):
+    assert not is_encodable(type_str, python_value)
+
+
+@given(single_strs_values)
+def test_is_encodable_returns_true_for_random_valid_values(type_and_value):
+    _type, value = type_and_value
+    assert is_encodable(_type, value)
+
+
+@given(tuple_strs_values)
+def test_is_encodable_returns_true_for_random_valid_tuple_values(type_and_value):
+    _type, value = type_and_value
+    assert is_encodable(_type, value)

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -65,14 +65,14 @@ def test_is_encodable_returns_false(type_str, python_value):
     assert not is_encodable(type_str, python_value)
 
 
-@settings(deadline=300)
+@settings(deadline=None)
 @given(single_strs_values)
 def test_is_encodable_returns_true_for_random_valid_values(type_and_value):
     _type, value = type_and_value
     assert is_encodable(_type, value)
 
 
-@settings(deadline=300)
+@settings(deadline=None)
 @given(tuple_strs_values)
 def test_is_encodable_returns_true_for_random_valid_tuple_values(type_and_value):
     _type, value = type_and_value

--- a/tests/test_abi/test_reversibility_properties.py
+++ b/tests/test_abi/test_reversibility_properties.py
@@ -17,7 +17,7 @@ from tests.common.strategies import (
 )
 
 
-@settings(deadline=300)
+@settings(deadline=None)
 @given(multi_strs_values)
 def test_multi_abi_reversibility(types_and_values):
     """
@@ -30,7 +30,7 @@ def test_multi_abi_reversibility(types_and_values):
     assert values == decoded_values
 
 
-@settings(deadline=300)
+@settings(deadline=None)
 @given(single_strs_values)
 def test_single_abi_reversibility(type_and_value):
     """
@@ -43,7 +43,7 @@ def test_single_abi_reversibility(type_and_value):
     assert value == decoded_value
 
 
-@settings(deadline=400)
+@settings(deadline=None)
 @given(tuple_strs_values)
 def test_single_abi_tuple_reversibility(type_and_value):
     """

--- a/tests/test_abi/test_reversibility_properties.py
+++ b/tests/test_abi/test_reversibility_properties.py
@@ -17,7 +17,7 @@ from tests.common.strategies import (
 )
 
 
-@settings(max_examples=1000)
+@settings(deadline=300)
 @given(multi_strs_values)
 def test_multi_abi_reversibility(types_and_values):
     """
@@ -30,7 +30,7 @@ def test_multi_abi_reversibility(types_and_values):
     assert values == decoded_values
 
 
-@settings(max_examples=1000)
+@settings(deadline=300)
 @given(single_strs_values)
 def test_single_abi_reversibility(type_and_value):
     """
@@ -43,6 +43,7 @@ def test_single_abi_reversibility(type_and_value):
     assert value == decoded_value
 
 
+@settings(deadline=400)
 @given(tuple_strs_values)
 def test_single_abi_tuple_reversibility(type_and_value):
     """

--- a/tests/test_decoding/test_decoder_properties.py
+++ b/tests/test_decoding/test_decoder_properties.py
@@ -85,7 +85,7 @@ def all_bytes_equal(test_bytes, target):
         return all(byte == target for byte in test_bytes)
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     integer_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     stream_bytes=st.binary(min_size=0, max_size=32),
@@ -130,7 +130,7 @@ def test_decode_unsigned_int(integer_bit_size, stream_bytes, data_byte_size):
     assert decoded_value == actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     integer_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     stream_bytes=st.binary(min_size=0, max_size=32),
@@ -187,7 +187,7 @@ def test_decode_signed_int(integer_bit_size, stream_bytes, data_byte_size):
     assert decoded_value == actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     string_bytes=st.binary(min_size=0, max_size=256),
     pad_size=st.integers(min_value=0, max_value=32),
@@ -209,7 +209,7 @@ def test_decode_bytes_and_string(string_bytes, pad_size):
     assert decoded_value == string_bytes
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     stream_bytes=st.binary(min_size=1, max_size=32),
     data_byte_size=st.integers(min_value=1, max_value=32),
@@ -245,7 +245,7 @@ def test_decode_boolean(stream_bytes, data_byte_size):
     assert decoded_value is actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     value_byte_size=st.integers(min_value=1, max_value=32),
     stream_bytes=st.binary(min_size=0, max_size=32),
@@ -283,7 +283,7 @@ def test_decode_bytes_xx(value_byte_size, stream_bytes, data_byte_size):
     assert decoded_value == actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     address_bytes=st.binary(min_size=0, max_size=32),
     padding_size=st.integers(min_value=10, max_value=14),
@@ -321,7 +321,7 @@ def test_decode_address(address_bytes, padding_size, data_byte_size):
     assert decoded_value == actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     array_size=st.integers(min_value=0, max_value=32),
     array_values=st.lists(st.integers(min_value=0, max_value=TT256M1), min_size=0, max_size=64).map(tuple),
@@ -380,7 +380,7 @@ def test_tuple_decoder(types, data, expected):
     assert actual == expected
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     high_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     low_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
@@ -443,7 +443,7 @@ def test_decode_unsigned_real(high_bit_size,
     assert decoded_value == actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     high_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     low_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
@@ -530,7 +530,7 @@ def test_decode_signed_real(high_bit_size,
     assert decoded_value == actual_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     value_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     frac_places=st.integers(min_value=1, max_value=80),
@@ -573,7 +573,7 @@ def test_decode_unsigned_fixed(value_bit_size,
     actual_value = decoder(stream)
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     value_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
     frac_places=st.integers(min_value=1, max_value=80),

--- a/tests/test_encoding/test_encoder_properties.py
+++ b/tests/test_encoding/test_encoder_properties.py
@@ -86,7 +86,7 @@ def test_encode_boolean(bool_value, data_byte_size):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @example(integer_value=-1, value_bit_size=8, data_byte_size=1)
 @given(
     integer_value=st.one_of(st.integers(), st.none()),
@@ -128,7 +128,7 @@ def test_encode_unsigned_integer(integer_value, value_bit_size, data_byte_size):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     integer_value=st.one_of(st.integers(), st.none()),
     value_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
@@ -176,7 +176,7 @@ def test_encode_signed_integer(integer_value, value_bit_size, data_byte_size):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     address_value=st.one_of(
         st.none(),
@@ -220,7 +220,7 @@ def test_encode_address(address_value, value_bit_size, data_byte_size):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     bytes_value=st.one_of(
         st.none(),
@@ -259,7 +259,7 @@ def test_encode_bytes_xx(bytes_value, value_bit_size, data_byte_size):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     string_value=st.one_of(
         st.none(),
@@ -289,7 +289,7 @@ def test_encode_byte_string(string_value):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     string_value=st.one_of(
         st.none(),
@@ -324,7 +324,7 @@ def test_encode_text_string(string_value):
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     base_integer_value=st.one_of(st.integers(), st.none()),
     high_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
@@ -395,7 +395,7 @@ def test_encode_unsigned_real(base_integer_value,
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     base_integer_value=st.one_of(st.integers(), st.none()),
     high_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
@@ -461,7 +461,7 @@ def test_encode_signed_real(base_integer_value,
     assert encoded_value == expected_value
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     value=st.one_of(st.integers(), st.decimals(), st.none()),
     value_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),
@@ -526,7 +526,7 @@ def test_encode_unsigned_fixed(value,
     encoder(value)
 
 
-@settings(max_examples=1000)
+@settings(max_examples=250)
 @given(
     value=st.one_of(st.integers(), st.decimals(), st.none()),
     value_bit_size=st.integers(min_value=1, max_value=32).map(lambda v: v * 8),


### PR DESCRIPTION
### What was wrong?

Currently, there is a poorly located and maintained version of `is_encodable` here: https://github.com/ethereum/web3.py/blob/master/web3/utils/abi.py#L148

This should be a part of the `eth_abi` library and should work in conjunction with new features like tuples and the registry.

### How was it fixed?

Made `validate_value` part of public API for encoder classes and added implementations of it where necessary.  Also added `abi.is_encodable` which is implemented via that new functionality.

#### Cute Animal Picture

![Cute animal picture](http://3.bp.blogspot.com/-HaG8YT-ThWw/T12rpMt8gSI/AAAAAAAAATk/odrpQf_Ty44/s1600/Cute-Tiger-Cub.jpg)