### PR TITLE
IllegalValue if fixed value has too many decimals

### DIFF
--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -307,7 +307,7 @@ class BaseFixedEncoder(NumberEncoder):
             residue = value % (TEN ** -self.frac_places)
 
         if residue > 0:
-            raise ValueError(
+            raise IllegalValue(
                 '{} cannot encode value {}: '
                 'residue {} outside allowed fractional precision of {}'.format(
                     type(self).__name__,

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -58,6 +58,7 @@ def test_is_encodable_returns_true(type_str, python_value, _):
         ('fixed8x1', Decimal('-129e-1')),
         ('ufixed8x1', Decimal('256e-1')),
         ('ufixed8x1', Decimal('-1e-1')),
+        ('fixed8x1', Decimal('1e-2')),
 
     )
 )

--- a/tests/test_encoding/test_encoder_properties.py
+++ b/tests/test_encoding/test_encoder_properties.py
@@ -468,6 +468,7 @@ def test_encode_signed_real(base_integer_value,
     frac_places=st.integers(min_value=1, max_value=80),
     data_byte_size=st.integers(min_value=0, max_value=32),
 )
+@example(value=decimal.Decimal('5.33'), value_bit_size=8, frac_places=1, data_byte_size=1)
 def test_encode_unsigned_fixed(value,
                                value_bit_size,
                                frac_places,
@@ -518,7 +519,7 @@ def test_encode_unsigned_fixed(value,
                 frac_places,
             )
         )
-        with pytest.raises(ValueError, match=pattern):
+        with pytest.raises(IllegalValue, match=pattern):
             encoder(value)
         return
 

--- a/tests/test_encoding/test_encoder_properties.py
+++ b/tests/test_encoding/test_encoder_properties.py
@@ -583,7 +583,7 @@ def test_encode_signed_fixed(value,
                 frac_places,
             )
         )
-        with pytest.raises(ValueError, match=pattern):
+        with pytest.raises(IllegalValue, match=pattern):
             encoder(value)
         return
 


### PR DESCRIPTION
### What was wrong?

`is_encodable` was crashing when a decimal has too many digits to encode with the given fixed ABI type, because it was raising `ValueError` which isn't caught.

### How was it fixed?

Raise `IllegalValue` instead

#### Cute Animal Picture

![Cute animal picture](http://i.imgur.com/tZQVH.jpg)
