### PR TITLE
disallow encoding floats to fixed type

### DIFF
--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -291,7 +291,10 @@ class SignedIntegerEncoder(NumberEncoder):
 
 class BaseFixedEncoder(NumberEncoder):
     frac_places = None
-    type_check_fn = staticmethod(is_number)
+
+    @staticmethod
+    def type_check_fn(value):
+        return is_number(value) and not isinstance(value, float)
 
     @staticmethod
     def illegal_value_fn(value):

--- a/tests/test_abi/test_is_encodable.py
+++ b/tests/test_abi/test_is_encodable.py
@@ -37,6 +37,7 @@ def test_is_encodable_returns_true(type_str, python_value, _):
         ('uint', True),
         ('int', True),
         ('bytes', 129),
+        ('fixed8x1', 0.1),  # only Decimal and int are allowed
 
         # List size mismatch
         ('int[3]', (6, 2)),


### PR DESCRIPTION
### What was wrong?

`float`s crashed when trying to encode them, because of the check for decimal "residue". They are imprecise anyway, by nature, and the eth-abi must be precise.

### How was it fixed?

Disallow `float` as a valid value to encode to a `fixedMxN` type.

#### Cute Animal Picture

![Cute animal picture](https://media.mnn.com/assets/images/2014/04/hawksbill-sea-turtle.jpg)