### PR TITLE
Add type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv
 pip-log.txt
 
 # Unit test / coverage reports
+.mypy_cache
 .coverage
 htmlcov/
 .tox

--- a/eth_abi/utils/numeric.py
+++ b/eth_abi/utils/numeric.py
@@ -1,4 +1,7 @@
 import decimal
+from typing import (
+    Tuple,
+)
 
 abi_decimal_context = decimal.Context(prec=999)
 
@@ -6,25 +9,28 @@ ZERO = decimal.Decimal(0)
 TEN = decimal.Decimal(10)
 
 
-def ceil32(x):
+def ceil32(x: int) -> int:
     return x if x % 32 == 0 else x + 32 - (x % 32)
 
 
-def compute_unsigned_integer_bounds(num_bits):
+def compute_unsigned_integer_bounds(num_bits: int) -> Tuple[int, int]:
     return (
         0,
         2 ** num_bits - 1,
     )
 
 
-def compute_signed_integer_bounds(num_bits):
+def compute_signed_integer_bounds(num_bits: int) -> Tuple[int, int]:
     return (
         -1 * 2 ** (num_bits - 1),
         2 ** (num_bits - 1) - 1,
     )
 
 
-def compute_unsigned_fixed_bounds(num_bits, frac_places):
+def compute_unsigned_fixed_bounds(
+    num_bits: int,
+    frac_places: int,
+) -> Tuple[decimal.Decimal, decimal.Decimal]:
     int_upper = compute_unsigned_integer_bounds(num_bits)[1]
 
     with decimal.localcontext(abi_decimal_context):
@@ -33,7 +39,10 @@ def compute_unsigned_fixed_bounds(num_bits, frac_places):
     return ZERO, upper
 
 
-def compute_signed_fixed_bounds(num_bits, frac_places):
+def compute_signed_fixed_bounds(
+    num_bits: int,
+    frac_places: int,
+) -> Tuple[decimal.Decimal, decimal.Decimal]:
     int_lower, int_upper = compute_signed_integer_bounds(num_bits)
 
     with decimal.localcontext(abi_decimal_context):

--- a/eth_abi/utils/padding.py
+++ b/eth_abi/utils/padding.py
@@ -4,7 +4,7 @@ from eth_utils.toolz import (
 
 
 @curry
-def zpad(value, length):
+def zpad(value: bytes, length: int) -> bytes:
     return value.rjust(length, b'\x00')
 
 
@@ -12,7 +12,7 @@ zpad32 = zpad(length=32)
 
 
 @curry
-def zpad_right(value, length):
+def zpad_right(value: bytes, length: int) -> bytes:
     return value.ljust(length, b'\x00')
 
 
@@ -20,7 +20,7 @@ zpad32_right = zpad_right(length=32)
 
 
 @curry
-def fpad(value, length):
+def fpad(value: bytes, length: int) -> bytes:
     return value.rjust(length, b'\xff')
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
+        "mypy==0.620",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/tox.ini
+++ b/tox.ini
@@ -41,3 +41,4 @@ extras=lint
 commands=
     flake8 {toxinidir}/eth_abi {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_abi {toxinidir}/tests
+    mypy --follow-imports=silent --ignore-missing-imports --check-untyped-defs --disallow-incomplete-defs -p eth_abi.utils


### PR DESCRIPTION
Also tox.ini: Add mypy to the CI

Closes: https://github.com/ethereum/eth-abi/issues/33

Sorry for taking so long to open this PR. I was busy with exams and GSoC preparations.
I will keep updating this.

### What was wrong?
Type hints were not present


### How was it fixed?
Mypy was added to the CI and type hints added to the packages


#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/564x/22/f6/68/22f6681cd1752c489fe1ef25af711bbd.jpg)
