### PR TITLE
Fix support for callable coders

### DIFF
--- a/eth_abi/abi.py
+++ b/eth_abi/abi.py
@@ -59,8 +59,13 @@ def is_encodable(typ, arg):
         encoder.validate_value(arg)
     except EncodingError:
         return False
-    else:
-        return True
+    except AttributeError:
+        try:
+            encoder(arg)
+        except EncodingError:
+            return False
+
+    return True
 
 
 # Decodes a single base datum

--- a/eth_abi/base.py
+++ b/eth_abi/base.py
@@ -144,4 +144,4 @@ class BaseCoder:
         Used by ``ABIRegistry`` to get an appropriate encoder or decoder
         instance for the given type string and type registry.
         """
-        raise NotImplementedError('Must implement `from_type_str`')
+        raise cls()

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -145,11 +145,11 @@ class TupleDecoder(BaseDecoder):
         super().__init__(**kwargs)
 
         self.decoders = tuple(
-            HeadTailDecoder(tail_decoder=d) if d.is_dynamic else d
+            HeadTailDecoder(tail_decoder=d) if getattr(d, 'is_dynamic', False) else d
             for d in self.decoders
         )
 
-        self.is_dynamic = any(d.is_dynamic for d in self.decoders)
+        self.is_dynamic = any(getattr(d, 'is_dynamic', False) for d in self.decoders)
 
     def validate(self):
         super().validate()

--- a/tests/test_integration/test_custom_registrations.py
+++ b/tests/test_integration/test_custom_registrations.py
@@ -1,0 +1,99 @@
+from eth_abi.abi import (
+    decode_single,
+    encode_single,
+)
+from eth_abi.decoding import (
+    BaseDecoder,
+)
+from eth_abi.encoding import (
+    BaseEncoder,
+)
+from eth_abi.exceptions import (
+    DecodingError,
+    EncodingError,
+)
+from eth_abi.registry import (
+    registry,
+)
+
+NULL_ENCODING = b'\x00' * 32
+
+
+def encode_null(x):
+    if x is not None:
+        raise EncodingError('Unsupported value')
+
+    return NULL_ENCODING
+
+
+def decode_null(stream):
+    if stream.read(32) != NULL_ENCODING:
+        raise DecodingError('Not enough data or wrong data')
+
+    return None
+
+
+class EncodeNull(BaseEncoder):
+    word_width = None
+
+    @classmethod
+    def from_type_str(cls, type_str, registry):
+        word_width = int(type_str[4:])
+        return cls(word_width=word_width)
+
+    def encode(self, value):
+        self.validate_value(value)
+        return NULL_ENCODING * self.word_width
+
+    def validate_value(self, value):
+        if value is not None:
+            raise EncodingError('Unsupported value')
+
+
+class DecodeNull(BaseDecoder):
+    word_width = None
+
+    @classmethod
+    def from_type_str(cls, type_str, registry):
+        word_width = int(type_str[4:])
+        return cls(word_width=word_width)
+
+    def decode(self, stream):
+        byts = stream.read(32 * self.word_width)
+        if byts != NULL_ENCODING * self.word_width:
+            raise DecodingError('Not enough data or wrong data')
+
+        return None
+
+
+def test_register_and_use_callables():
+    registry.register('null', encode_null, decode_null)
+
+    assert encode_single('null', None) == NULL_ENCODING
+    assert decode_single('null', NULL_ENCODING) is None
+
+    encoded_tuple = encode_single('(int,null)', (1, None))
+
+    assert encoded_tuple == b'\x00' * 31 + b'\x01' + NULL_ENCODING
+    assert decode_single('(int,null)', encoded_tuple) == (1, None)
+
+    registry.unregister('null')
+
+
+def test_register_and_use_coder_classes():
+    registry.register(
+        lambda x: x.startswith('null'),
+        EncodeNull,
+        DecodeNull,
+        label='null',
+    )
+
+    assert encode_single('null2', None) == NULL_ENCODING * 2
+    assert decode_single('null2', NULL_ENCODING * 2) is None
+
+    encoded_tuple = encode_single('(int,null2)', (1, None))
+
+    assert encoded_tuple == b'\x00' * 31 + b'\x01' + NULL_ENCODING * 2
+    assert decode_single('(int,null2)', encoded_tuple) == (1, None)
+
+    registry.unregister('null')


### PR DESCRIPTION
### What was wrong?

When adding support for tuple types and the `is_encodable` function, support for simple callable coders was broken.

### How was it fixed?

Modified code in `is_encodable` as well as `encoding` and `decoding` modules to handle simple callables.  Added tests for functionality that wasn't working as expected.

#### Cute Animal Picture

![Cute animal picture](https://i.redd.it/1773dopqnf011.jpg)
