### PR TITLE
Fix lack of cleanup for stateful tests

### DIFF
--- a/tests/test_integration/test_custom_registrations.py
+++ b/tests/test_integration/test_custom_registrations.py
@@ -69,15 +69,16 @@ class DecodeNull(BaseDecoder):
 def test_register_and_use_callables():
     registry.register('null', encode_null, decode_null)
 
-    assert encode_single('null', None) == NULL_ENCODING
-    assert decode_single('null', NULL_ENCODING) is None
+    try:
+        assert encode_single('null', None) == NULL_ENCODING
+        assert decode_single('null', NULL_ENCODING) is None
 
-    encoded_tuple = encode_single('(int,null)', (1, None))
+        encoded_tuple = encode_single('(int,null)', (1, None))
 
-    assert encoded_tuple == b'\x00' * 31 + b'\x01' + NULL_ENCODING
-    assert decode_single('(int,null)', encoded_tuple) == (1, None)
-
-    registry.unregister('null')
+        assert encoded_tuple == b'\x00' * 31 + b'\x01' + NULL_ENCODING
+        assert decode_single('(int,null)', encoded_tuple) == (1, None)
+    finally:
+        registry.unregister('null')
 
 
 def test_register_and_use_coder_classes():
@@ -88,12 +89,13 @@ def test_register_and_use_coder_classes():
         label='null',
     )
 
-    assert encode_single('null2', None) == NULL_ENCODING * 2
-    assert decode_single('null2', NULL_ENCODING * 2) is None
+    try:
+        assert encode_single('null2', None) == NULL_ENCODING * 2
+        assert decode_single('null2', NULL_ENCODING * 2) is None
 
-    encoded_tuple = encode_single('(int,null2)', (1, None))
+        encoded_tuple = encode_single('(int,null2)', (1, None))
 
-    assert encoded_tuple == b'\x00' * 31 + b'\x01' + NULL_ENCODING * 2
-    assert decode_single('(int,null2)', encoded_tuple) == (1, None)
-
-    registry.unregister('null')
+        assert encoded_tuple == b'\x00' * 31 + b'\x01' + NULL_ENCODING * 2
+        assert decode_single('(int,null2)', encoded_tuple) == (1, None)
+    finally:
+        registry.unregister('null')


### PR DESCRIPTION
### What was wrong?

Some stateful tests introduced in PR #76 did not cleanup after themselves.

### How was it fixed?

Wrapped test code in try/finally blocks to automatically clean up state changes.

#### Cute Animal Picture

![Cute animal picture](http://londonbeep.com/wp-content/uploads/2015/04/lazy-cat-tries-to-help-16.jpg)
