### PR TITLE
Return string type as utf-8 decoded string

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -608,11 +608,15 @@ class StringDecoder(ByteStringDecoder):
     def decoder_fn(data):
         try:
             value = data.decode("utf-8")
-        except UnicodeDecodeError:
+        except UnicodeDecodeError as e:
             raise UnicodeDecodeError(
+                e.encoding,
+                e.object,
+                e.start,
+                e.end,
                 "The returned type for this function is string which is "
                 "expected to be a UTF8 encoded string of text. The returned "
-                "value {0} could not be decoded as valid UTF8. This is indicative "
+                "value could not be decoded as valid UTF8. This is indicative "
                 "of a broken application which is using incorrect return types for "
-                "binary data.".format(data))
+                "binary data.")
         return value

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -560,7 +560,7 @@ class SignedRealDecoder(BaseRealDecoder):
 #
 # String and Bytes
 #
-class StringDecoder(SingleDecoder):
+class ByteStringDecoder(SingleDecoder):
     is_dynamic = True
 
     @staticmethod
@@ -594,12 +594,25 @@ class StringDecoder(SingleDecoder):
     def validate_padding_bytes(self, value, padding_bytes):
         pass
 
+    @parse_type_str('bytes')
+    def from_type_str(cls, abi_type, registry):
+        return cls()
+
+
+class StringDecoder(ByteStringDecoder):
     @parse_type_str('string')
     def from_type_str(cls, abi_type, registry):
         return cls()
 
-
-class ByteStringDecoder(StringDecoder):
-    @parse_type_str('bytes')
-    def from_type_str(cls, abi_type, registry):
-        return cls()
+    @staticmethod
+    def decoder_fn(data):
+        try:
+            value = data.decode("utf-8")
+        except UnicodeDecodeError:
+            raise UnicodeDecodeError(
+                "The returned type for this function is string which is "
+                "expected to be a UTF8 encoded string of text. The returned "
+                "value {0} could not be decoded as valid UTF8. This is indicative "
+                "of a broken application which is using incorrect return types for "
+                "binary data.".format(data))
+        return value

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -17,6 +17,7 @@ from eth_abi.base import (
     parse_type_str,
 )
 from eth_abi.exceptions import (
+    DecodingError,
     InsufficientDataBytes,
     NonEmptyPaddingBytes,
 )
@@ -609,7 +610,7 @@ class StringDecoder(ByteStringDecoder):
         try:
             value = data.decode("utf-8")
         except UnicodeDecodeError as e:
-            raise UnicodeDecodeError(
+            raise DecodingError(
                 e.encoding,
                 e.object,
                 e.start,
@@ -618,5 +619,5 @@ class StringDecoder(ByteStringDecoder):
                 "expected to be a UTF8 encoded string of text. The returned "
                 "value could not be decoded as valid UTF8. This is indicative "
                 "of a broken application which is using incorrect return types for "
-                "binary data.")
+                "binary data.") from e
         return value

--- a/tests/test_decoding/test_decoder_properties.py
+++ b/tests/test_decoding/test_decoder_properties.py
@@ -35,6 +35,7 @@ from eth_abi.decoding import (
     UnsignedRealDecoder,
 )
 from eth_abi.exceptions import (
+    DecodingError,
     InsufficientDataBytes,
     NonEmptyPaddingBytes,
 )
@@ -245,25 +246,25 @@ def is_utf8_encodable(value):
 
 @settings(max_examples=250)
 @given(
-    _strings=st.binary(min_size=0, max_size=256),
+    _bytes=st.binary(min_size=0, max_size=256),
     pad_size=st.integers(min_value=0, max_value=32),
 )
-def test_decode_strings_raises(_strings, pad_size):
-    size_bytes = zpad32(int_to_big_endian(len(_strings)))
-    padded_bytes = _strings + b'\x00' * pad_size
+def test_decode_strings_raises(_bytes, pad_size):
+    size_bytes = zpad32(int_to_big_endian(len(_bytes)))
+    padded_bytes = _bytes + b'\x00' * pad_size
     stream_bytes = size_bytes + padded_bytes
     stream = ContextFramesBytesIO(stream_bytes)
 
     decoder = StringDecoder()
 
-    st.assume(not is_utf8_decodable(_strings))
+    st.assume(not is_utf8_decodable(_bytes))
 
-    if len(padded_bytes) < ceil32(len(_strings)):
+    if len(padded_bytes) < ceil32(len(_bytes)):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
 
-    with pytest.raises(UnicodeDecodeError):
+    with pytest.raises(DecodingError):
         decoder(stream)
 
 

--- a/tests/test_decoding/test_decoder_properties.py
+++ b/tests/test_decoding/test_decoder_properties.py
@@ -22,6 +22,7 @@ from eth_abi.decoding import (
     AddressDecoder,
     BooleanDecoder,
     BytesDecoder,
+    ByteStringDecoder,
     ContextFramesBytesIO,
     DynamicArrayDecoder,
     SignedFixedDecoder,
@@ -183,24 +184,87 @@ def test_decode_signed_int(integer_bit_size, stream_bytes, data_byte_size):
 
 @settings(max_examples=250)
 @given(
-    string_bytes=st.binary(min_size=0, max_size=256),
+    _bytes=st.binary(min_size=0, max_size=256),
     pad_size=st.integers(min_value=0, max_value=32),
 )
-def test_decode_bytes_and_string(string_bytes, pad_size):
-    size_bytes = zpad32(int_to_big_endian(len(string_bytes)))
-    padded_string_bytes = string_bytes + b'\x00' * pad_size
-    stream_bytes = size_bytes + padded_string_bytes
+def test_decode_bytes(_bytes, pad_size):
+    size_bytes = zpad32(int_to_big_endian(len(_bytes)))
+    padded_bytes = _bytes + b'\x00' * pad_size
+    stream_bytes = size_bytes + padded_bytes
     stream = ContextFramesBytesIO(stream_bytes)
 
-    decoder = StringDecoder()
+    decoder = ByteStringDecoder()
 
-    if len(padded_string_bytes) < ceil32(len(string_bytes)):
+    if len(padded_bytes) < ceil32(len(_bytes)):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
 
     decoded_value = decoder(stream)
-    assert decoded_value == string_bytes
+    assert decoded_value == _bytes
+
+
+@settings(max_examples=250)
+@given(
+    _strings=st.text(min_size=0, max_size=256),
+    pad_size=st.integers(min_value=0, max_value=32),
+)
+def test_decode_strings(_strings, pad_size):
+    st.assume(is_utf8_encodable(_strings))
+    size_bytes = zpad32(int_to_big_endian(len(_strings.encode("utf-8"))))
+    padded_bytes = _strings.encode("utf-8") + b'\x00' * pad_size
+    stream_bytes = size_bytes + padded_bytes
+    stream = ContextFramesBytesIO(stream_bytes)
+
+    decoder = StringDecoder()
+
+    if len(padded_bytes) < ceil32(len(_strings.encode("utf-8"))):
+        with pytest.raises(InsufficientDataBytes):
+            decoder(stream)
+        return
+
+    decoded_value = decoder(stream)
+    assert decoded_value == _strings
+
+
+def is_utf8_decodable(value):
+    try:
+        value.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def is_utf8_encodable(value):
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+@settings(max_examples=250)
+@given(
+    _strings=st.binary(min_size=0, max_size=256),
+    pad_size=st.integers(min_value=0, max_value=32),
+)
+def test_decode_strings_raises(_strings, pad_size):
+    size_bytes = zpad32(int_to_big_endian(len(_strings)))
+    padded_bytes = _strings + b'\x00' * pad_size
+    stream_bytes = size_bytes + padded_bytes
+    stream = ContextFramesBytesIO(stream_bytes)
+
+    decoder = StringDecoder()
+
+    st.assume(not is_utf8_decodable(_strings))
+
+    if len(padded_bytes) < ceil32(len(_strings)):
+        with pytest.raises(InsufficientDataBytes):
+            decoder(stream)
+        return
+
+    with pytest.raises(UnicodeDecodeError):
+        decoder(stream)
 
 
 @settings(max_examples=250)


### PR DESCRIPTION
### What was wrong?
string types are return as utf-8 encoded bytes.  Makes more sense to return as utf-8 decoded string type.

See #81 


### How was it fixed?
Added a utf-8 decoding step to the StringDecoder.


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/8933231/42773243-8b4687fc-88e1-11e8-94b4-2a2c1bde45a6.png)
