### PR TITLE
Remove collapse type

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -9,6 +9,11 @@ Development
   - Added support for nested dynamic arrays from the Solidity version 2 ABI
   - Added support for non-standard packed mode encoding
   - Added support for tuple array types e.g. ``(int,int)[]``
+- Backwards Incompatible Changes
+
+  - The :meth:`~eth_abi.abi.encode_single` and
+    :meth:`~eth_abi.abi.decode_single` functions no longer accept type tuples
+    to identify ABI types.  Only type strings are accepted.
 
 v2.0.0-alpha.1
 -------------
@@ -20,9 +25,6 @@ Released July 19, 2018
   - :meth:`~eth_abi.abi.decode_single` called with ABI type 'string' will now return a python
     :class:`str` instead of :class:`bytes`.
   - Support for the legacy ``real`` and ``ureal`` types has been removed
-  - The :meth:`~eth_abi.abi.encode_single` and
-    :meth:`~eth_abi.abi.decode_single` functions no longer accept type tuples
-    to identify ABI types.  Only type strings are accepted.
 - Bugfixes
 
   - Simple callable encoders work again

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -20,6 +20,9 @@ Released July 19, 2018
   - :meth:`~eth_abi.abi.decode_single` called with ABI type 'string' will now return a python
     :class:`str` instead of :class:`bytes`.
   - Support for the legacy ``real`` and ``ureal`` types has been removed
+  - The :meth:`~eth_abi.abi.encode_single` and
+    :meth:`~eth_abi.abi.decode_single` functions no longer accept type tuples
+    to identify ABI types.  Only type strings are accepted.
 - Bugfixes
 
   - Simple callable encoders work again

--- a/eth_abi/abi.py
+++ b/eth_abi/abi.py
@@ -26,7 +26,6 @@ from eth_abi.registry import (
     registry,
 )
 from eth_abi.utils.parsing import (  # noqa: F401
-    collapse_type,
     process_type,
 )
 
@@ -42,12 +41,7 @@ def encode_single(typ: TypeStr, arg: Any) -> bytes:
     :returns: The binary representation of the python value ``arg`` as a value
         of the ABI type ``typ``.
     """
-    if isinstance(typ, str):
-        type_str = typ
-    else:
-        type_str = collapse_type(*typ)
-
-    encoder = registry.get_encoder(type_str)
+    encoder = registry.get_encoder(typ)
 
     return encoder(arg)
 
@@ -87,12 +81,7 @@ def is_encodable(typ: TypeStr, arg: Any) -> bool:
     :returns: ``True`` if ``arg`` is encodable as a value of the ABI type
         ``typ``.  Otherwise, ``False``.
     """
-    if isinstance(typ, str):
-        type_str = typ
-    else:
-        type_str = collapse_type(*typ)
-
-    encoder = registry.get_encoder(type_str)
+    encoder = registry.get_encoder(typ)
 
     try:
         encoder.validate_value(arg)
@@ -122,12 +111,7 @@ def decode_single(typ: TypeStr, data: Decodable) -> Any:
     if not is_bytes(data):
         raise TypeError("The `data` value must be of bytes type.  Got {0}".format(type(data)))
 
-    if isinstance(typ, str):
-        type_str = typ
-    else:
-        type_str = collapse_type(*typ)
-
-    decoder = registry.get_decoder(type_str)
+    decoder = registry.get_decoder(typ)
     stream = ContextFramesBytesIO(data)
 
     return decoder(stream)

--- a/eth_abi/packed.py
+++ b/eth_abi/packed.py
@@ -14,9 +14,6 @@ from eth_abi.encoding import (
 from eth_abi.registry import (
     registry_packed,
 )
-from eth_abi.utils.parsing import (
-    collapse_type,
-)
 
 warnings.warn(
     "Packed mode encoding is an experimental feature.  Please report any "
@@ -36,12 +33,7 @@ def encode_single_packed(typ: TypeStr, arg: Any) -> bytes:
     :returns: The non-standard packed mode binary representation of the python
         value ``arg`` as a value of the ABI type ``typ``.
     """
-    if isinstance(typ, str):
-        type_str = typ
-    else:
-        type_str = collapse_type(*typ)
-
-    encoder = registry_packed.get_encoder(type_str)
+    encoder = registry_packed.get_encoder(typ)
 
     return encoder(arg)
 

--- a/eth_abi/utils/parsing.py
+++ b/eth_abi/utils/parsing.py
@@ -43,7 +43,3 @@ def process_type(type_str):
         arrlist = []
 
     return abi_type.base, sub, arrlist
-
-
-def collapse_type(base, sub, arrlist):
-    return base + sub + ''.join(map(repr, arrlist))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'test': [
         "pytest==3.3.2",
         "pytest-pythonpath>=0.7.1",
-        "pytest-xdist",
+        "pytest-xdist==1.22.3",
         "hypothesis>=3.6.1",
         "tox>=2.9.1,<3",
         "eth-hash[pycryptodome]",

--- a/tests/common/unit.py
+++ b/tests/common/unit.py
@@ -264,9 +264,6 @@ CORRECT_TUPLE_ENCODINGS = [
 ]
 
 CORRECT_SINGLE_ENCODINGS = CORRECT_TUPLE_ENCODINGS + [
-    # encode_single/decode_single accept tuple of type components
-    (('uint', '256', []), 2 ** 256 - 1, words('f<f'), words('f<f')),
-
     #####
     # (type string, python value, abi encoding, packed encoding)
     #####

--- a/tests/test_utils/test_parsing.py
+++ b/tests/test_utils/test_parsing.py
@@ -4,7 +4,6 @@ from eth_abi.exceptions import (
     ParseError,
 )
 from eth_abi.utils.parsing import (
-    collapse_type,
     process_type,
 )
 
@@ -64,20 +63,3 @@ def test_process_validation_errors(typestr):
 def test_process_parsing_errors(typestr):
     with pytest.raises(ParseError):
         process_type(typestr)
-
-
-@pytest.mark.parametrize(
-    'original, expected',
-    [
-        ('address', 'address'),
-        ('uint[2][]', 'uint256[2][]'),
-        ('uint256[2][]', 'uint256[2][]'),
-        ('function', 'bytes24'),
-        ('bool', 'bool'),
-        ('bytes32', 'bytes32'),
-        ('bytes', 'bytes'),
-        ('string', 'string'),
-    ],
-)
-def test_collapse_type(original, expected):
-    assert collapse_type(*process_type(original)) == expected


### PR DESCRIPTION
### What was wrong?

See issue #86 .

### How was it fixed?

Removed `collapse_type`.  Modified behavior of `encode_single`, `is_encodable`, and `decode_single`.

#### Cute Animal Picture

![Cute animal picture](http://animals.sandiegozoo.org/sites/default/files/2016-09/animals_hero_redpanda.jpg)
