### PR TITLE
Update arrays to use head-tail encoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ common: &common
         when: on_fail
     - restore_cache:
         keys:
-          - v2-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - v4-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -33,7 +33,7 @@ common: &common
           - ~/.cache/pip
           - ~/.local
           - ./eggs
-        key: v3-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        key: v4-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
   doctest:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Table of Contents
     encoding
     decoding
     registry
+    nested_dynamic_arrays
     eth_abi
     releases
 

--- a/docs/nested_dynamic_arrays.rst
+++ b/docs/nested_dynamic_arrays.rst
@@ -1,0 +1,12 @@
+Nested Dynamic Arrays
+=====================
+
+The ``eth-abi`` library supports the Solidity ABIv2 encoding format for nested
+dynamic arrays.  This means that values for data types such as the following
+are legal and encodable/decodable: ``int[][]``, ``string[]``, ``string[2]``,
+etc.
+
+.. warning::
+
+    Though Solidity's ABIv2 has mostly been finalized, the specification is
+    technically still in development and may change.

--- a/eth_abi/utils/padding.py
+++ b/eth_abi/utils/padding.py
@@ -1,4 +1,4 @@
-from cytoolz import (
+from eth_utils.toolz import (
     curry,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     url='https://github.com/ethereum/eth-abi',
     include_package_data=True,
     install_requires=[
-        'eth-utils>=1.0.1,<2.0.0',
+        'eth-utils>=1.2.0,<2.0.0',
         'eth-typing<=2',
         'parsimonious==0.8.0',
     ],

--- a/tests/common/unit.py
+++ b/tests/common/unit.py
@@ -176,20 +176,89 @@ CORRECT_TUPLE_ENCODINGS = [
     ),
     (
         '((int,int[],(int,int)[]),(int,int),int)',
-        ((1, (2, 3), ((4, 5), (6, 7))), (8, 9), 10),
-        words('80', '8', '9', 'a', '1', '60', 'c0', '2', '2', '3', '2', '4', '5', '6', '7'),
+        (
+            (
+                1,
+                (2, 3),
+                ((4, 5), (6, 7)),
+            ),
+            (8, 9),
+            10,
+        ),
+        words(
+            '80',  # offset of dynamic tuple
+            '8',  # outer tuple static tuple
+            '9',
+            'a',  # outer tuple int
+            '1',  # beginning of dynamic tuple (int)
+            '60',  # offset of dynamic tuple list of ints
+            'c0',  # offset of dynamic tuple list of tuples
+            '2',  # size of list of ints
+            '2',
+            '3',
+            '2',  # size of list of tuples
+            '4',  # beginning of first tuple
+            '5',
+            '6',  # beginning of second tuple
+            '7',
+        ),
         words('1', '2', '3', '4', '5', '6', '7', '8', '9', 'a'),
     ),
     (
         '(int,int)[][]',
-        (((1, 2),), ((3, 4), (5, 6)), ((7, 8), (9, 10), (11, 12))),
-        words('3', '1', '1', '2', '2', '3', '4', '5', '6', '3', '7', '8', '9', 'a', 'b', 'c'),
+        (
+            ((1, 2),),
+            ((3, 4), (5, 6)),
+            ((7, 8), (9, 10), (11, 12)),
+        ),
+        words(
+            '3',  # size of outer dynamic list
+            '60',  # offset of first dynamic list
+            'c0',  # offset of second dynamic list
+            '160',  # offset of third dynamic list
+            '1',  # size of first list
+            '1',  # start of first tuple
+            '2',
+            '2',  # size of second list
+            '3',  # start of second tuple
+            '4',
+            '5',  # start of third tuple
+            '6',
+            '3',  # size of third list
+            '7',  # start of fourth tuple
+            '8',
+            '9',  # start of fifth tuple
+            'a',
+            'b',  # start of sixth tuple
+            'c',
+        ),
         words('1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c'),
     ),
     (
         '((int,int)[][2])',
-        ((((1, 2), (3, 4)), ((5, 6), (7, 8), (9, 10))),),
-        words('20', '2', '1', '2', '3', '4', '3', '5', '6', '7', '8', '9', 'a'),
+        (
+            (
+                ((1, 2), (3, 4)),
+                ((5, 6), (7, 8), (9, 10)),
+            ),
+        ),
+        words(
+            '20',  # offset of constant size array
+            '40',  # offset of first dynamic list of tuples
+            'e0',  # offset of second dynamic list of tuples
+            '2',  # size of first list
+            '1',  # start of first tuple
+            '2',
+            '3',  # start of second tuple
+            '4',
+            '3',  # size of second list
+            '5',  # start of third tuple
+            '6',
+            '7',  # start of fourth tuple
+            '8',
+            '9',  # start of fifth tuple
+            'a',
+        ),
         words('1', '2', '3', '4', '5', '6', '7', '8', '9', 'a'),
     ),
 ]

--- a/tests/test_decoding/test_decoder_properties.py
+++ b/tests/test_decoding/test_decoder_properties.py
@@ -1,13 +1,13 @@
 import sys
 
-from cytoolz import (
-    complement,
-)
 from eth_utils import (
     big_endian_to_int,
     decode_hex,
     int_to_big_endian,
     to_normalized_address,
+)
+from eth_utils.toolz import (
+    complement,
 )
 from hypothesis import (
     example,


### PR DESCRIPTION
### What was wrong?

Array encoding was not using head-tail encoding when necessary (for dynamic elements) as was discovered in the discussion for this PR: #90 .

Closes #93 

### How was it fixed?

Added this behavior and updated tests.

#### Cute Animal Picture

![Cute animal picture](http://4.bp.blogspot.com/-Mx-FdFW2PtQ/TmOZa-ZkKOI/AAAAAAAAAzY/3CnOMq1WgL4/s1600/red_panda_2.jpg)
