### PR TITLE
Fix slow hypothesis tests

### DIFF
--- a/tests/common/strategies.py
+++ b/tests/common/strategies.py
@@ -104,6 +104,7 @@ malformed_tuple_type_strs = st.recursive(
         st.one_of(malformed_non_tuple_type_strs, this_strategy),
         min_size=1, max_size=10,
     ),
+    max_leaves=5,
 ).map(join_tuple)
 
 malformed_type_strs = st.one_of(


### PR DESCRIPTION
### What was wrong?

See issue #96 .

### How was it fixed?

Restricted the number of leaves possible in data generated by recursive strategy.

#### Cute Animal Picture

![Cute animal picture](http://2.bp.blogspot.com/-bBCuRrUXpK4/UFb2_pkm6uI/AAAAAAAAArI/rYYCM2BmENs/s1600/Red+Panda+Walking.jpg)
