### PR TITLE
Fix eth-typing major version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing<=2',
+        'eth-typing<2',
         'parsimonious==0.8.0',
     ],
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
### What was wrong?

The dependency on eth-typing permitted an upgrade to eth-typing v2

### How was it fixed?

The dependency was reduced from `<=2` to `<2`.

#### Cute Animal Picture

![Cute animal picture](http://www.friendskorner.com/forum/photopost/data/505/Twin_Animals_4.jpg)
