### PR TITLE
Fix eth-typing major version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing<=2',
+        'eth-typing<2',
         'parsimonious==0.8.0',
     ],
     extras_require={


### PR DESCRIPTION
Backported from #99 master to v1

#### Cute Animal Picture

![Cute animal picture](https://thenypost.files.wordpress.com/2017/12/star_porg1a.jpg?quality=90&strip=all&w=618&h=410&crop=1)
