### PR TITLE
Loosen the parsimonious constraint to accept 0.8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         'eth-utils>=1.2.0,<2.0.0',
         'eth-typing<2',
-        'parsimonious==0.8.0',
+        'parsimonious>=0.8.0,<0.9.0',
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',


### PR DESCRIPTION
### What was wrong?

evmlab was having install issues with 0.8.0. See:
- https://travis-ci.org/ethereum/evmlab/builds/443182730
- https://colab.research.google.com/drive/1ArOehY-0SCYdgFiJV6XXG3Le5S6rTwV_

### How was it fixed?

Accept up to v0.9.0 (exclusive)

Patch releases in parsimonious shouldn't break the API, even at v0.

#### Cute Animal Picture

![Cute animal picture](https://qph.fs.quoracdn.net/main-qimg-a86593fe58bb27eb99287363328c3b39-c)
