### PR TITLE
updating to eth-typing to 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing==2.0.0',
+        'eth-typing>=2.0.0,<3.0.0',
         'parsimonious>=0.8.0,<0.9.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing<2',
+        'eth-typing==2.0.0',
         'parsimonious>=0.8.0,<0.9.0',
     ],
     extras_require={


### PR DESCRIPTION
### What was wrong?

eth-typing was fixed to the minor version of 2.0.0. Due to https://github.com/ethereum/py-evm/issues/1484, we need a new version with that dependency updated.

### How was it fixed?

Updating the dependency was enough. Test are passing. Didn't find any breaking change from 1.3 to 2.0.0, neither in code or documentation.
