### PR TITLE
Support eth-typing v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing<2',
+        'eth-typing>=1,<3',
         'parsimonious>=0.8.0,<0.9.0',
     ],
     setup_requires=['setuptools-markdown'],


### PR DESCRIPTION
### What was wrong?

eth-typing v2 was forbidden, many other packages require v2 now

### How was it fixed?

Bump the version and see what happens in CI.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/14/a1/7c/14a17c97633c43996f78ce266e37fb0a.jpg)
