### PR TITLE
Registry copying functionality

### DIFF
--- a/docs/codecs.rst
+++ b/docs/codecs.rst
@@ -56,3 +56,38 @@ We then create a custom codec object with our custom registry and use this to
 encode and decode byte sequences.  This allows us to continue using the
 porcelain API (described in the :ref:`encoding` and :ref:`decoding` sections)
 with our custom registry.
+
+.. _copying_an_existing_registry:
+
+Copying an Existing Registry
+----------------------------
+
+Sometimes, it's more convenient to use an existing registry but with only one or
+two small modifications.  This can be done via a registry's copying or cloning
+capability coupled with the use of a custom codec:
+
+.. testcode:: custom-registry-copied
+
+    from eth_abi.codec import ABICodec
+    from eth_abi.registry import registry as default_registry
+
+    registry = default_registry.copy()
+    registry.unregister('address')
+
+    codec = ABICodec(registry)
+
+    try:
+        codec.encode_single('address', None)
+    except ValueError:
+        pass
+    else:
+        # We shouldn't reach this since the above code will cause an exception
+        raise Exception('unreachable')
+
+    default_codec = ABICodec(default_registry)
+
+    # The default registry is unaffected since a copy was made
+    assert (
+        default_codec.encode_single('address', '0x' + 'ff' * 20) ==
+        b'\x00' * 12 + b'\xff' * 20
+    )

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Development
+-----------
+
+- Added registry copying functionality to facilitate modification of the
+  default registry.  See :ref:`copying_an_existing_registry`.
+
 v2.0.0-beta.4
 -------------
 

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -439,6 +439,14 @@ class ABIRegistry(Copyable):
         return self._get_coder(self._decoders, type_str)
 
     def copy(self):
+        """
+        Copies a registry such that new registrations can be made or existing
+        registrations can be unregistered without affecting any instance from
+        which a copy was obtained.  This is useful if an existing registry
+        fulfills most of a user's needs but requires one or two modifications.
+        In that case, a copy of that registry can be obtained and the necessary
+        changes made without affecting the original registry.
+        """
         cpy = type(self)()
 
         cpy._encoders = copy.copy(self._encoders)

--- a/tests/test_registry/test_predicate_mapping.py
+++ b/tests/test_registry/test_predicate_mapping.py
@@ -1,4 +1,6 @@
+import copy
 import functools
+import itertools
 import operator
 
 import pytest
@@ -102,3 +104,26 @@ def test_removing_non_existent_label_raises_error(mapping):
 def test_removing_unsupported_type_raises_error(mapping):
     with pytest.raises(TypeError, match=r'must be callable or string.*got <class \'bool\'>'):
         mapping.remove(True)
+
+
+def test_copying_copies_internal_mappings_but_not_predicates_or_values(mapping: PredicateMapping):
+    mapping.add(equals_foo, 'foo value', 'foo label')
+
+    c1 = mapping.copy()
+    c2 = copy.copy(mapping)
+    c3 = copy.deepcopy(mapping)
+
+    for x, y in itertools.combinations((mapping, c1, c2, c3), 2):
+        # Objects are different
+        assert id(x) != id(y)
+
+        # Names are the same
+        assert x._name == y._name
+
+        # Internal mapping objects are different
+        assert id(x._values) != id(y._values)
+        assert id(x._labeled_predicates) != id(y._labeled_predicates)
+
+        # Values for 'foo' can be found in both mappings
+        assert x.find('foo') == 'foo value'
+        assert y.find('foo') == 'foo value'

--- a/tests/test_registry/test_predicate_mapping.py
+++ b/tests/test_registry/test_predicate_mapping.py
@@ -20,7 +20,7 @@ equals_foo = Equals('foo')
 equals_bar = Equals('bar')
 
 
-def test_can_add_predicates_and_find_corresponding_values(mapping):
+def test_can_add_predicates_and_find_corresponding_values(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value')
     mapping.add(equals_bar, 'bar value')
 
@@ -28,7 +28,7 @@ def test_can_add_predicates_and_find_corresponding_values(mapping):
     assert mapping.find('bar') == 'bar value'
 
 
-def test_cannot_add_same_predicate_twice(mapping):
+def test_cannot_add_same_predicate_twice(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value')
 
     pattern = r'Matcher .* already exists in registry'
@@ -36,7 +36,7 @@ def test_cannot_add_same_predicate_twice(mapping):
         mapping.add(equals_foo, 'foo value')
 
 
-def test_cannot_add_two_predicates_with_same_label(mapping):
+def test_cannot_add_two_predicates_with_same_label(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value', 'some label')
 
     pattern = r"Matcher .* with label 'some label' already exists in registry"
@@ -44,7 +44,7 @@ def test_cannot_add_two_predicates_with_same_label(mapping):
         mapping.add(equals_bar, 'bar value', 'some label')
 
 
-def test_no_matching_predicates_should_raise_error(mapping):
+def test_no_matching_predicates_should_raise_error(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value')
     mapping.add(equals_bar, 'bar value')
 
@@ -52,7 +52,7 @@ def test_no_matching_predicates_should_raise_error(mapping):
         mapping.find('baz')
 
 
-def test_multiple_matching_predicates_should_raise_error(mapping):
+def test_multiple_matching_predicates_should_raise_error(mapping: PredicateMapping):
     mapping.add(Equals('baz'), 'baz value')
     mapping.add(functools.partial(operator.eq, 'baz'), 'baz value')
 
@@ -64,7 +64,7 @@ def test_multiple_matching_predicates_should_raise_error(mapping):
     e.match(r'functools\.partial')
 
 
-def test_can_remove_predicates_by_reference(mapping):
+def test_can_remove_predicates_by_reference(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value')
     assert mapping.find('foo') == 'foo value'
 
@@ -73,12 +73,12 @@ def test_can_remove_predicates_by_reference(mapping):
         mapping.find('foo')
 
 
-def test_removing_non_existent_predicate_raises_error(mapping):
+def test_removing_non_existent_predicate_raises_error(mapping: PredicateMapping):
     with pytest.raises(KeyError, match=r'Matcher .* not found in registry'):
         mapping.remove(equals_foo)
 
 
-def test_removing_labeled_predicate_by_reference_also_removes_label(mapping):
+def test_removing_labeled_predicate_by_reference_also_removes_label(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value', 'foo label')
     mapping.remove(equals_foo)
 
@@ -87,7 +87,7 @@ def test_removing_labeled_predicate_by_reference_also_removes_label(mapping):
     assert len(mapping._labeled_predicates) == 0
 
 
-def test_can_remove_predicates_by_label_if_label_was_given(mapping):
+def test_can_remove_predicates_by_label_if_label_was_given(mapping: PredicateMapping):
     mapping.add(equals_foo, 'foo value', 'foo label')
     assert mapping.find('foo') == 'foo value'
 
@@ -96,12 +96,12 @@ def test_can_remove_predicates_by_label_if_label_was_given(mapping):
         mapping.find('foo')
 
 
-def test_removing_non_existent_label_raises_error(mapping):
+def test_removing_non_existent_label_raises_error(mapping: PredicateMapping):
     with pytest.raises(KeyError, match=r"Label 'asdf' not found in registry"):
         mapping.remove('asdf')
 
 
-def test_removing_unsupported_type_raises_error(mapping):
+def test_removing_unsupported_type_raises_error(mapping: PredicateMapping):
     with pytest.raises(TypeError, match=r'must be callable or string.*got <class \'bool\'>'):
         mapping.remove(True)
 


### PR DESCRIPTION
### What was wrong?

We needed a facility for copying existing registries so we can use eth-abi for web3.py's encodability checks.

### How was it fixed?

Added copying functionality to `ABIRegistry` and supporting classes.

#### Cute Animal Picture

![Cute animal picture](https://rabbit.org/articles/wp-content/uploads/2013/02/Ingo.jpg)
