### PR TITLE
Make throwing of value validation errors more consistent

### DIFF
--- a/eth_abi/utils/string.py
+++ b/eth_abi/utils/string.py
@@ -1,0 +1,19 @@
+from typing import (
+    Any,
+)
+
+
+def abbr(value: Any, limit: int=20) -> str:
+    """
+    Converts a value into its string representation and abbreviates that
+    representation based on the given length `limit` if necessary.
+    """
+    rep = repr(value)
+
+    if len(rep) > limit:
+        if limit < 3:
+            raise ValueError('Abbreviation limit may not be less than 3')
+
+        rep = rep[:limit - 3] + '...'
+
+    return rep

--- a/tests/test_encoding/test_encoder_properties.py
+++ b/tests/test_encoding/test_encoder_properties.py
@@ -1,6 +1,5 @@
 import codecs
 import decimal
-import re
 
 from eth_utils import (
     decode_hex,
@@ -345,7 +344,7 @@ def test_encode_unsigned_fixed(value,
     )
 
     if not is_number(value):
-        pattern = r'Value of type .*NoneType.* cannot be encoded by UnsignedFixedEncoder'
+        pattern = r'Value `None` of type .*NoneType.* cannot be encoded by UnsignedFixedEncoder'
         with pytest.raises(EncodingTypeError, match=pattern):
             encoder(value)
         return
@@ -358,7 +357,10 @@ def test_encode_unsigned_fixed(value,
 
     lower, upper = compute_unsigned_fixed_bounds(value_bit_size, frac_places)
     if value < lower or value > upper:
-        pattern = r'Value .* cannot be encoded in .* bits'
+        pattern = (
+            r'Value .* cannot be encoded by UnsignedFixedEncoder: '
+            r'Cannot be encoded in .* bits'
+        )
         with pytest.raises(ValueOutOfBounds, match=pattern):
             encoder(value)
         return
@@ -366,14 +368,7 @@ def test_encode_unsigned_fixed(value,
     with decimal.localcontext(abi_decimal_context):
         residue = value % (TEN ** -frac_places)
     if residue > 0:
-        pattern = re.escape(
-            'UnsignedFixedEncoder cannot encode value {}: '
-            'residue {} outside allowed fractional precision of {}'.format(
-                repr(value),
-                repr(residue),
-                frac_places,
-            )
-        )
+        pattern = r'Value .* cannot be encoded by UnsignedFixedEncoder: residue .* outside allowed'
         with pytest.raises(IllegalValue, match=pattern):
             encoder(value)
         return
@@ -410,7 +405,7 @@ def test_encode_signed_fixed(value,
     )
 
     if not is_number(value):
-        pattern = r'Value of type .*NoneType.* cannot be encoded by SignedFixedEncoder'
+        pattern = r'Value `None` of type .*NoneType.* cannot be encoded by SignedFixedEncoder'
         with pytest.raises(EncodingTypeError, match=pattern):
             encoder(value)
         return
@@ -423,7 +418,7 @@ def test_encode_signed_fixed(value,
 
     lower, upper = compute_signed_fixed_bounds(value_bit_size, frac_places)
     if value < lower or value > upper:
-        pattern = r'Value .* cannot be encoded in .* bits'
+        pattern = r'Value .* cannot be encoded by SignedFixedEncoder: Cannot be encoded in .* bits'
         with pytest.raises(ValueOutOfBounds, match=pattern):
             encoder(value)
         return
@@ -431,14 +426,7 @@ def test_encode_signed_fixed(value,
     with decimal.localcontext(abi_decimal_context):
         residue = value % (TEN ** -frac_places)
     if residue > 0:
-        pattern = re.escape(
-            'SignedFixedEncoder cannot encode value {}: '
-            'residue {} outside allowed fractional precision of {}'.format(
-                repr(value),
-                repr(residue),
-                frac_places,
-            )
-        )
+        pattern = r'Value .* cannot be encoded by SignedFixedEncoder: residue .* outside allowed'
         with pytest.raises(IllegalValue, match=pattern):
             encoder(value)
         return

--- a/tests/test_utils/test_abbr.py
+++ b/tests/test_utils/test_abbr.py
@@ -1,0 +1,30 @@
+import pytest
+
+from eth_abi.utils.string import (
+    abbr,
+)
+
+
+@pytest.mark.parametrize(
+    'value,expected,limit',
+    (
+        (1234567891234567891, '1234567891234567891', None),
+        (12345678912345678912, '12345678912345678912', None),
+        (123456789123456789123, '12345678912345678...', None),
+        ('asdf' * 30, "'asdfasdfasdfasdf...", None),
+        (list(range(100)), '[0, 1, 2, 3, 4, 5...', None),
+        (1234567891234567891, '...', 3),
+        (1234567891234567891, '1...', 4),
+    )
+)
+def test_abbr(value, expected, limit):
+    if limit is not None:
+        actual = abbr(value, limit)
+    else:
+        actual = abbr(value)
+    assert actual == expected
+
+
+def test_abbr_throws_value_errors():
+    with pytest.raises(ValueError):
+        abbr('asdf', limit=2)


### PR DESCRIPTION
### What was wrong?

It seems necessary to have a bit of API for throwing validation errors instead of having all these floating `raise` statements that may or may not throw the correct error type with a useful message.

### How was it fixed?

Created the `invalidate_value` method on `BaseEncoder` so there's a controlled way of doing this.

#### Cute Animal Picture

![Cute animal picture](https://hdpicturehub.com/wp-content/uploads/2016/12/fox-pictures-HD3-1.jpg)
