### PR TITLE
Change ABIType.__str__ to ABIType.to_type_str

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -174,7 +174,10 @@ class TupleDecoder(BaseDecoder):
 
     @parse_tuple_type_str
     def from_type_str(cls, abi_type, registry):
-        decoders = tuple(registry.get_decoder(str(c)) for c in abi_type.components)
+        decoders = tuple(
+            registry.get_decoder(c.to_type_str())
+            for c in abi_type.components
+        )
 
         return cls(decoders=decoders)
 
@@ -226,7 +229,7 @@ class BaseArrayDecoder(BaseDecoder):
 
     @parse_type_str(with_arrlist=True)
     def from_type_str(cls, abi_type, registry):
-        item_decoder = registry.get_decoder(str(abi_type.item_type))
+        item_decoder = registry.get_decoder(abi_type.item_type.to_type_str())
 
         array_spec = abi_type.arrlist[-1]
         if len(array_spec) == 1:

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -164,7 +164,10 @@ class TupleEncoder(BaseEncoder):
 
     @parse_tuple_type_str
     def from_type_str(cls, abi_type, registry):
-        encoders = tuple(registry.get_encoder(str(c)) for c in abi_type.components)
+        encoders = tuple(
+            registry.get_encoder(c.to_type_str())
+            for c in abi_type.components
+        )
 
         return cls(encoders=encoders)
 
@@ -629,7 +632,7 @@ class BaseArrayEncoder(BaseEncoder):
 
     @parse_type_str(with_arrlist=True)
     def from_type_str(cls, abi_type, registry):
-        item_encoder = registry.get_encoder(str(abi_type.item_type))
+        item_encoder = registry.get_encoder(abi_type.item_type.to_type_str())
 
         array_spec = abi_type.arrlist[-1]
         if len(array_spec) == 1:
@@ -666,7 +669,7 @@ class PackedArrayEncoder(BaseArrayEncoder):
 
     @parse_type_str(with_arrlist=True)
     def from_type_str(cls, abi_type, registry):
-        item_encoder = registry.get_encoder(str(abi_type.item_type))
+        item_encoder = registry.get_encoder(abi_type.item_type.to_type_str())
 
         array_spec = abi_type.arrlist[-1]
         if len(array_spec) == 1:

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -141,23 +141,25 @@ class ABIType:
         self.node = node
 
     def __repr__(self):  # pragma: no cover
-        return '<{} {}>'.format(type(self).__qualname__, repr(str(self)))
+        return '<{} {}>'.format(
+            type(self).__qualname__,
+            repr(self.to_type_str()),
+        )
 
     def __eq__(self, other):
         """
-        Two ABI types are equal if their canonical string representations are
-        equal.
+        Two ABI types are equal if their string representations are equal.
         """
         return (
             type(self) is type(other) and
-            str(self) == str(other)
+            self.to_type_str() == other.to_type_str()
         )
 
-    def __str__(self):  # pragma: no cover
+    def to_type_str(self):  # pragma: no cover
         """
-        An ABI type must have a canonical string representation.
+        An ABI type must be convertible to a string representation.
         """
-        raise NotImplementedError('Must implement `__str__`')
+        raise NotImplementedError('Must implement `to_type_str`')
 
     def validate(self):  # pragma: no cover
         """
@@ -212,13 +214,18 @@ class TupleType(ABIType):
 
         self.components = components
 
-    def __str__(self):
+    def to_type_str(self):
         arrlist = self.arrlist
+
         if isinstance(arrlist, tuple):
             arrlist = ''.join(repr(list(a)) for a in arrlist)
         else:
             arrlist = ''
-        return '({}){}'.format(','.join(str(c) for c in self.components), arrlist)
+
+        return '({}){}'.format(
+            ','.join(c.to_type_str() for c in self.components),
+            arrlist,
+        )
 
     @property
     def item_type(self):
@@ -226,9 +233,9 @@ class TupleType(ABIType):
         If this type is an array type, returns the type of the array's items.
         """
         if self.arrlist is None:
-            raise ValueError(
-                "Cannot determine item type for non-array type '{}'".format(self)
-            )
+            raise ValueError("Cannot determine item type for non-array type '{}'".format(
+                self.to_type_str(),
+            ))
 
         return type(self)(
             self.components,
@@ -265,7 +272,7 @@ class BasicType(ABIType):
         self.base = base
         self.sub = sub
 
-    def __str__(self):
+    def to_type_str(self):
         sub, arrlist = self.sub, self.arrlist
 
         if isinstance(sub, int):
@@ -288,9 +295,9 @@ class BasicType(ABIType):
         If this type is an array type, returns the type of the array's items.
         """
         if self.arrlist is None:
-            raise ValueError(
-                "Cannot determine item type for non-array type '{}'".format(self)
-            )
+            raise ValueError("Cannot determine item type for non-array type '{}'".format(
+                self.to_type_str(),
+            ))
 
         return type(self)(
             self.base,

--- a/tests/test_abi/test_decode_abi.py
+++ b/tests/test_abi/test_decode_abi.py
@@ -24,7 +24,7 @@ def test_decode_abi(type_str, expected, abi_encoding, _):
     if abi_type.arrlist is not None:
         pytest.skip('ABI coding functions do not support array types')
 
-    types = [str(t) for t in abi_type.components]
+    types = [t.to_type_str() for t in abi_type.components]
 
     actual = decode_abi(types, abi_encoding)
     assert actual == expected

--- a/tests/test_abi/test_encode_abi.py
+++ b/tests/test_abi/test_encode_abi.py
@@ -21,7 +21,7 @@ def test_encode_abi(type_str, python_value, abi_encoding, _):
     if abi_type.arrlist is not None:
         pytest.skip('ABI coding functions do not support array types')
 
-    types = [str(t) for t in abi_type.components]
+    types = [t.to_type_str() for t in abi_type.components]
 
     actual = encode_abi(types, python_value)
     assert actual == abi_encoding

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -117,7 +117,7 @@ def test_parse_raises_type_error_for_wrong_data_type():
 
 @given(type_strs)
 def test_end_to_end_parsing_and_collapsing(type_str):
-    assert str(parse(type_str)) == type_str
+    assert parse(type_str).to_type_str() == type_str
 
 
 @pytest.mark.parametrize(

--- a/tests/test_packed/test_encode_abi_packed.py
+++ b/tests/test_packed/test_encode_abi_packed.py
@@ -20,7 +20,7 @@ def test_encode_abi(type_str, python_value, _, packed_encoding):
     if abi_type.arrlist is not None:
         pytest.skip('ABI coding functions do not support array types')
 
-    types = [str(t) for t in abi_type.components]
+    types = [t.to_type_str() for t in abi_type.components]
 
     actual = encode_abi_packed(types, python_value)
     assert actual == packed_encoding


### PR DESCRIPTION
### What was wrong?

Piper [mentioned](https://github.com/ethereum/web3.py/pull/1249#discussion_r258565787) that the API of using the `str` builtin to convert `ABIType` instances to canonical type strings is a bit risky.

### How was it fixed?

Added a more explicit `to_canonical_type_str` function for this purpose.

#### Cute Animal Picture

![Cute animal picture](https://www.wildlifeaid.org.uk/wp-content/uploads/2016/03/FP9_July09.jpg)
