### PR TITLE
Update officially supported python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,30 +48,23 @@ jobs:
       - image: circleci/python:3.5
         environment:
           TOXENV: lint
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
-  pypy3-core:
+  py37-core:
     <<: *common
     docker:
-      - image: pypy
+      - image: circleci/python:3.7
         environment:
-          TOXENV: pypy3-core
+          TOXENV: py37-core
 workflows:
   version: 2
   test:
     jobs:
       - doctest
       - lint
-      - py35-core
       - py36-core
-      - pypy3-core
+      - py37-core

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ clean-pyc:
 lint:
 	tox -e lint
 
+lint-roll:
+	isort --recursive eth_abi tests
+	$(MAKE) lint
+
 test:
 	py.test tests
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Development
+-----------
+
+- Removed PyPy support.
+- Added Python 3.7 support.
+
 v2.0.0-beta.6
 -------------
 

--- a/eth_abi/__init__.py
+++ b/eth_abi/__init__.py
@@ -1,12 +1,11 @@
 import pkg_resources
 
 from eth_abi.abi import (  # NOQA
-    decode_single,
     decode_abi,
-    encode_single,
+    decode_single,
     encode_abi,
+    encode_single,
     is_encodable,
 )
-
 
 __version__ = pkg_resources.get_distribution('eth-abi').version

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,py3}-core
+    py{36,37}-core
     lint
     doctest
 
@@ -26,9 +26,8 @@ commands=
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python
-    py35: python3.5
     py36: python3.6
-    pypy3: pypy3
+    py37: python3.7
 extras=
     test
     doctest: doc


### PR DESCRIPTION
### What was wrong?

Looks like web3.py only tests against python 3.6 and 3.7.

### How was it fixed?

Updated testing config to do the same.

#### Cute Animal Picture

![Cute animal picture](http://images.mentalfloss.com/sites/default/files/styles/mf_image_3x2/public/istock_000009294687_small.jpg?itok=igUVFAip&resize=1100x740)
