### PR TITLE
Add API for checking type validity against coder registrations

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+Development
+-----------
+
+- Added  :meth:`~eth_abi.registry.ABIRegistry.has_encoder` and
+  :meth:`~eth_abi.codec.ABIEncoder.is_encodable_type` to facilitate checking
+  for type validity against coder registrations.
+
 v2.0.0-beta.7
 -------------
 

--- a/eth_abi/__init__.py
+++ b/eth_abi/__init__.py
@@ -6,6 +6,7 @@ from eth_abi.abi import (  # NOQA
     encode_abi,
     encode_single,
     is_encodable,
+    is_encodable_type,
 )
 
 __version__ = pkg_resources.get_distribution('eth-abi').version

--- a/eth_abi/abi.py
+++ b/eth_abi/abi.py
@@ -12,3 +12,4 @@ encode_single = default_codec.encode_single
 decode_abi = default_codec.decode_abi
 decode_single = default_codec.decode_single
 is_encodable = default_codec.is_encodable
+is_encodable_type = default_codec.is_encodable_type

--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -113,6 +113,20 @@ class ABIEncoder(BaseABICoder):
 
         return True
 
+    def is_encodable_type(self, typ: TypeStr) -> bool:
+        """
+        Returns ``True`` if values for the ABI type ``typ`` can be encoded by
+        this codec.
+
+        :param typ: A string representation for the ABI type that will be
+            checked for encodability e.g. ``'uint256'``, ``'bytes[]'``,
+            ``'(int,int)'``, etc.
+
+        :returns: ``True`` if values for ``typ`` can be encoded by this codec.
+            Otherwise, ``False``.
+        """
+        return self._registry.has_encoder(typ)
+
 
 class ABIDecoder(BaseABICoder):
     """

--- a/eth_abi/exceptions.py
+++ b/eth_abi/exceptions.py
@@ -99,6 +99,11 @@ class NoEntriesFound(ValueError, PredicateMappingError):
     """
     Raised when no registration is found for a type string in a registry's
     internal mapping.
+
+    ..warning::
+
+        In a future version of ``eth-abi``, this error class will no longer
+        inherit from ``ValueError``.
     """
     pass
 
@@ -106,6 +111,13 @@ class NoEntriesFound(ValueError, PredicateMappingError):
 class MultipleEntriesFound(ValueError, PredicateMappingError):
     """
     Raised when multiple registrations are found for a type string in a
-    registry's internal mapping.
+    registry's internal mapping.  This error is non-recoverable and indicates
+    that a registry was configured incorrectly.  Registrations are expected to
+    cover completely distinct ranges of type strings.
+
+    ..warning::
+
+        In a future version of ``eth-abi``, this error class will no longer
+        inherit from ``ValueError``.
     """
     pass

--- a/eth_abi/exceptions.py
+++ b/eth_abi/exceptions.py
@@ -86,3 +86,26 @@ class ABITypeError(ValueError):
     that is not congruent with zero modulo eight).
     """
     pass
+
+
+class PredicateMappingError(Exception):
+    """
+    Raised when an error occurs with the registry's internal mapping.
+    """
+    pass
+
+
+class NoEntriesFound(ValueError, PredicateMappingError):
+    """
+    Raised when no registration is found for a type string in the registry's
+    internal mapping.
+    """
+    pass
+
+
+class MultipleEntriesFound(ValueError, PredicateMappingError):
+    """
+    Raised when multiple registrations are found for a type string in the
+    registry's internal mapping.
+    """
+    pass

--- a/eth_abi/exceptions.py
+++ b/eth_abi/exceptions.py
@@ -90,14 +90,14 @@ class ABITypeError(ValueError):
 
 class PredicateMappingError(Exception):
     """
-    Raised when an error occurs with the registry's internal mapping.
+    Raised when an error occurs in a registry's internal mapping.
     """
     pass
 
 
 class NoEntriesFound(ValueError, PredicateMappingError):
     """
-    Raised when no registration is found for a type string in the registry's
+    Raised when no registration is found for a type string in a registry's
     internal mapping.
     """
     pass
@@ -105,7 +105,7 @@ class NoEntriesFound(ValueError, PredicateMappingError):
 
 class MultipleEntriesFound(ValueError, PredicateMappingError):
     """
-    Raised when multiple registrations are found for a type string in the
+    Raised when multiple registrations are found for a type string in a
     registry's internal mapping.
     """
     pass

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -438,6 +438,18 @@ class ABIRegistry(Copyable):
     def get_encoder(self, type_str):
         return self._get_coder(self._encoders, type_str)
 
+    def has_encoder(self, type_str: abi.TypeStr) -> bool:
+        """
+        Returns ``True`` if at least one encoder is found for the given type
+        string ``type_str``.  Otherwise, returns ``False``.
+        """
+        try:
+            self.get_encoder(type_str)
+        except NoEntriesFound:
+            return False
+        else:
+            return True
+
     @functools.lru_cache(maxsize=None)
     def get_decoder(self, type_str):
         return self._get_coder(self._decoders, type_str)

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -440,8 +440,10 @@ class ABIRegistry(Copyable):
 
     def has_encoder(self, type_str: abi.TypeStr) -> bool:
         """
-        Returns ``True`` if at least one encoder is found for the given type
-        string ``type_str``.  Otherwise, returns ``False``.
+        Returns ``True`` if an encoder is found for the given type string
+        ``type_str``.  Otherwise, returns ``False``.  Raises
+        :class:`~eth_abi.exceptions.MultipleEntriesFound` if multiple encoders
+        are found.
         """
         try:
             self.get_encoder(type_str)

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -21,6 +21,10 @@ from . import (
 from .base import (
     BaseCoder,
 )
+from .exceptions import (
+    MultipleEntriesFound,
+    NoEntriesFound,
+)
 
 Lookup = Union[abi.TypeStr, Callable[[abi.TypeStr], bool]]
 
@@ -82,7 +86,7 @@ class PredicateMapping(Copyable):
         )
 
         if len(results) == 0:
-            raise ValueError("No matching entries for '{}' in {}".format(
+            raise NoEntriesFound("No matching entries for '{}' in {}".format(
                 type_str,
                 self._name,
             ))
@@ -90,7 +94,7 @@ class PredicateMapping(Copyable):
         predicates, values = tuple(zip(*results))
 
         if len(results) > 1:
-            raise ValueError("Multiple matching entries for '{}' in {}: {}".format(
+            raise MultipleEntriesFound("Multiple matching entries for '{}' in {}: {}".format(
                 type_str,
                 self._name,
                 ', '.join(map(repr, predicates)),

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -94,11 +94,15 @@ class PredicateMapping(Copyable):
         predicates, values = tuple(zip(*results))
 
         if len(results) > 1:
-            raise MultipleEntriesFound("Multiple matching entries for '{}' in {}: {}".format(
-                type_str,
-                self._name,
-                ', '.join(map(repr, predicates)),
-            ))
+            predicate_reprs = ', '.join(map(repr, predicates))
+            raise MultipleEntriesFound(
+                f"Multiple matching entries for '{type_str}' in {self._name}: "
+                f"{predicate_reprs}. This occurs when two registrations match the "
+                "same type string. You may need to delete one of the "
+                "registrations or modify its matching behavior to ensure it "
+                "doesn't collide with other registrations. See the \"Registry\" "
+                "documentation for more information."
+            )
 
         return values[0]
 

--- a/tests/test_abi/test_is_encodable_type.py
+++ b/tests/test_abi/test_is_encodable_type.py
@@ -1,0 +1,20 @@
+import pytest
+
+from eth_abi import (
+    is_encodable_type,
+)
+from tests.common.unit import (
+    CORRECT_SINGLE_ENCODINGS,
+)
+
+
+@pytest.mark.parametrize(
+    'type_str,_python_value,_1,_2',
+    CORRECT_SINGLE_ENCODINGS,
+)
+def test_is_encodable_type_returns_true(type_str, _python_value, _1, _2):
+    assert is_encodable_type(type_str)
+
+
+def test_is_encodable_type_returns_false():
+    assert not is_encodable_type('foo')

--- a/tests/test_registry/test_abi_registry.py
+++ b/tests/test_registry/test_abi_registry.py
@@ -172,15 +172,6 @@ def test_copying_copies_internal_mappings(registry: ABIRegistry):
 def test_has_encoder_returns_true(registry: ABIRegistry):
     assert registry.has_encoder('address')
 
-    registry.register(
-        BaseEquals('address', with_sub=False),
-        encoding.AddressEncoder, decoding.AddressDecoder,
-        label='other_address',
-    )
-
-    with pytest.raises(exceptions.MultipleEntriesFound):
-        assert registry.has_encoder('address')
-
 
 def test_has_encoder_raises(registry: ABIRegistry):
     registry.register(

--- a/tests/test_registry/test_abi_registry.py
+++ b/tests/test_registry/test_abi_registry.py
@@ -71,12 +71,9 @@ def test_cache_resets_after_register_and_register_works(registry: ABIRegistry):
     )
 
     # Confirm cache reset
-    pattern = r'Multiple matching entries .* encoder registry'
-    with pytest.raises(ValueError, match=pattern):
+    with pytest.raises(exceptions.MultipleEntriesFound):
         registry.get_encoder('address')
-
-    pattern = r'Multiple matching entries .* decoder registry'
-    with pytest.raises(ValueError, match=pattern):
+    with pytest.raises(exceptions.MultipleEntriesFound):
         registry.get_decoder('address')
 
 
@@ -89,9 +86,9 @@ def test_cache_resets_after_unregister_and_unregister_works(registry: ABIRegistr
     registry.unregister('address')
 
     # Confirm cache reset
-    with pytest.raises(ValueError, match=r'No matching entries .* encoder registry'):
+    with pytest.raises(exceptions.NoEntriesFound):
         registry.get_encoder('address')
-    with pytest.raises(ValueError, match=r'No matching entries .* decoder registry'):
+    with pytest.raises(exceptions.NoEntriesFound):
         registry.get_decoder('address')
 
 
@@ -107,9 +104,9 @@ def test_can_register_and_unregister_string_lookups(registry: ABIRegistry):
 
     registry.unregister('bool')
 
-    with pytest.raises(ValueError, match=r'No matching entries .* encoder registry'):
+    with pytest.raises(exceptions.NoEntriesFound):
         registry.get_encoder('bool')
-    with pytest.raises(ValueError, match=r'No matching entries .* decoder registry'):
+    with pytest.raises(exceptions.NoEntriesFound):
         registry.get_decoder('bool')
 
 
@@ -123,9 +120,9 @@ def test_registry_should_reject_unknown_types(registry: ABIRegistry):
 def test_can_unregister_by_equality(registry: ABIRegistry):
     registry.unregister(BaseEquals('address'))
 
-    with pytest.raises(ValueError, match=r'No matching entries .* encoder registry'):
+    with pytest.raises(exceptions.NoEntriesFound):
         registry.get_encoder('address')
-    with pytest.raises(ValueError, match=r'No matching entries .* decoder registry'):
+    with pytest.raises(exceptions.NoEntriesFound):
         registry.get_decoder('address')
 
 

--- a/tests/test_registry/test_abi_registry.py
+++ b/tests/test_registry/test_abi_registry.py
@@ -167,3 +167,31 @@ def test_copying_copies_internal_mappings(registry: ABIRegistry):
         assert isinstance(x.get_decoder('address'), decoding.AddressDecoder)
         assert isinstance(y.get_encoder('address'), encoding.AddressEncoder)
         assert isinstance(y.get_decoder('address'), decoding.AddressDecoder)
+
+
+def test_has_encoder_returns_true(registry: ABIRegistry):
+    assert registry.has_encoder('address')
+
+    registry.register(
+        BaseEquals('address', with_sub=False),
+        encoding.AddressEncoder, decoding.AddressDecoder,
+        label='other_address',
+    )
+
+    with pytest.raises(exceptions.MultipleEntriesFound):
+        assert registry.has_encoder('address')
+
+
+def test_has_encoder_raises(registry: ABIRegistry):
+    registry.register(
+        BaseEquals('address', with_sub=False),
+        encoding.AddressEncoder, decoding.AddressDecoder,
+        label='other_address',
+    )
+
+    with pytest.raises(exceptions.MultipleEntriesFound):
+        assert registry.has_encoder('address')
+
+
+def test_has_encoder_returns_false(registry: ABIRegistry):
+    assert not registry.has_encoder('foo')


### PR DESCRIPTION
### What was wrong?

The `is_encodable` method made some implicit assumptions that value encodability would only be checked for types recognizable by the registry.

### How was it fixed?

Added methods `is_encodable_type` and `has_encoder` to the public API and registry respectively to provide functionality for checking type validity.

#### Cute Animal Picture

![Cute animal picture](https://www.zooborns.com/.a/6a010535647bf3970b019affa34d55970b-800wi)
