### PR TITLE
Add ABIDecoder.stream_class property

### DIFF
--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -132,6 +132,8 @@ class ABIDecoder(BaseABICoder):
     """
     Wraps a registry to provide last-mile decoding functionality.
     """
+    stream_class = ContextFramesBytesIO
+
     def decode_single(self, typ: TypeStr, data: Decodable) -> Any:
         """
         Decodes the binary value ``data`` of the ABI type ``typ`` into its
@@ -148,7 +150,7 @@ class ABIDecoder(BaseABICoder):
             raise TypeError("The `data` value must be of bytes type.  Got {0}".format(type(data)))
 
         decoder = self._registry.get_decoder(typ)
-        stream = ContextFramesBytesIO(data)
+        stream = self.stream_class(data)
 
         return decoder(stream)
 
@@ -174,7 +176,7 @@ class ABIDecoder(BaseABICoder):
         ]
 
         decoder = TupleDecoder(decoders=decoders)
-        stream = ContextFramesBytesIO(data)
+        stream = self.stream_class(data)
 
         return decoder(stream)
 


### PR DESCRIPTION
### What was wrong?

A user had the need to customize the behavior of the `ContextFramesBytesIO` class as was discussed in #135 .

### How was it fixed?

Added a class property called `stream_class` to `ABIDecoder` which can be overridden in subclasses.

#### Cute Animal Picture

![Cute animal picture](https://pgcpsmess.files.wordpress.com/2014/04/red-fox-eyes.jpg)
