### PR TITLE
Add alias "byte" for "bytes1"

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -405,6 +405,7 @@ TYPE_ALIASES = {
     'fixed': 'fixed128x18',
     'ufixed': 'ufixed128x18',
     'function': 'bytes24',
+    'byte': 'bytes1',
 }
 
 TYPE_ALIAS_RE = re.compile(r'\b({})\b'.format(

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -196,7 +196,7 @@ def test_valid_abi_types(type_str):
     'type_str, normalized',
     tuple(TYPE_ALIASES.items()) + (
         ('(int,uint,fixed,ufixed)', '(int256,uint256,fixed128x18,ufixed128x18)'),
-        ('(function,function,function)', '(bytes24,bytes24,bytes24)'),
+        ('(function,function,(function,byte))', '(bytes24,bytes24,(bytes24,bytes1))'),
     ),
 )
 def test_normalize(type_str, normalized):


### PR DESCRIPTION
### What was wrong?

Just realized recently that the type "byte" is an official alias "bytes1" according to the Solidity docs here: https://solidity.readthedocs.io/en/v0.5.13/types.html#fixed-size-byte-arrays

### How was it fixed?

Modified `normalize` function to replace instance of "byte" with "bytes1".

#### Cute Animal Picture

![Cute animal picture](http://3.bp.blogspot.com/-yaj2AVzRU8c/U8gTnPyU1YI/AAAAAAABBAc/eT0ZXhnbNsQ/s1600/cute-red-panda-07.jpg)
