### PR TITLE
use self reference rather than super

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -81,7 +81,7 @@ class ContextFramesBytesIO(io.BytesIO):
         """
         Seeks relative to the total offset of the current contextual frames.
         """
-        super().seek(self._total_offset + pos, *args, **kwargs)
+        self.seek(self._total_offset + pos, *args, **kwargs)
 
     def push_frame(self, offset):
         """


### PR DESCRIPTION
This change aligns the use of seek with the use in pop_frame
Additionally, inheritants can now override the behaviour of the seek call in seek_in_frame(...)

### What was wrong?
The call to seek in seek_in_frame() was using super() to get a reference to the function seek().


### How was it fixed?
super() -> self


#### Cute Animal Picture

![Cute animal picture](https://images.unsplash.com/photo-1560114928-40f1f1eb26a0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2550&q=80)
