### PR TITLE
fix for python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
 workflows:
   version: 2
   test:
@@ -68,3 +74,4 @@ workflows:
       - lint
       - py36-core
       - py37-core
+      - py38-core

--- a/newsfragments/145.feature.rst
+++ b/newsfragments/145.feature.rst
@@ -1,0 +1,1 @@
+Add support for python 3.8

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import (
     find_packages,
 )
 
-HYPOTHESIS_REQUIREMENT = "hypothesis>=3.6.1,<4"
+HYPOTHESIS_REQUIREMENT = "hypothesis>=4.18.2,<5.0.0"
 
 extras_require = {
     'tools': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-core
+    py{36,37,38}-core
     lint
     docs
 
@@ -28,6 +28,7 @@ basepython =
     docs: python
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 extras=
     test
     docs: doc


### PR DESCRIPTION
## What was wrong?
due to difference in of constructor and positional arguments in python 3.8, hypothesis needs to be a higher versio

Issue #143

## How was it fixed?

hpyothesis version bump to 4.18.2
https://github.com/HypothesisWorks/hypothesis/pull/1944
Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
