### PR TITLE
fix: catch ABITypeError exceptions when checking type

### DIFF
--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -22,6 +22,7 @@ from .base import (
     BaseCoder,
 )
 from .exceptions import (
+    ABITypeError,
     MultipleEntriesFound,
     NoEntriesFound,
 )
@@ -459,7 +460,7 @@ class ABIRegistry(Copyable, BaseRegistry):
         """
         try:
             self.get_encoder(type_str)
-        except NoEntriesFound:
+        except (ABITypeError, NoEntriesFound):
             return False
         else:
             return True


### PR DESCRIPTION
## What was wrong?

Issue #147

## How was it fixed?

Catch `ABITypeError` and return False
