### PR TITLE
feat: use checksummed address over normalized

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -7,7 +7,7 @@ from typing import (
 
 from eth_utils import (
     big_endian_to_int,
-    to_normalized_address,
+    to_checksum_address,
     to_tuple,
 )
 
@@ -365,7 +365,7 @@ class BooleanDecoder(Fixed32ByteSizeDecoder):
 class AddressDecoder(Fixed32ByteSizeDecoder):
     value_bit_size = 20 * 8
     is_big_endian = True
-    decoder_fn = staticmethod(to_normalized_address)
+    decoder_fn = staticmethod(to_checksum_address)
 
     @parse_type_str('address')
     def from_type_str(cls, abi_type, registry):

--- a/tests/test_decoding/test_decoder_properties.py
+++ b/tests/test_decoding/test_decoder_properties.py
@@ -4,7 +4,7 @@ from eth_utils import (
     big_endian_to_int,
     decode_hex,
     int_to_big_endian,
-    to_normalized_address,
+    to_checksum_address,
 )
 from eth_utils.toolz import (
     complement,
@@ -369,7 +369,7 @@ def test_decode_address(address_bytes, padding_size, data_byte_size):
     else:
         decoded_value = decoder(stream)
 
-    actual_value = to_normalized_address(stream_bytes[:data_byte_size][-20:])
+    actual_value = to_checksum_address(stream_bytes[:data_byte_size][-20:])
 
     assert decoded_value == actual_value
 


### PR DESCRIPTION
## What was wrong?

Use checksummed address instead of normalized

## How was it fixed?

Change the decoding method used

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![baby_bats](https://user-images.githubusercontent.com/19540978/145152358-45262d64-491f-469b-9cf9-b4c59700a723.jpeg)


