### PR TITLE
Update eth-typing, eth-utils dependency requirements

### DIFF
--- a/newsfragments/154.misc.rst
+++ b/newsfragments/154.misc.rst
@@ -1,0 +1,1 @@
+Update eth-utils dependency to >=2.0.0,<3.0.0, and eth-typing to >=3.0.0,<4.0.0

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
     url='https://github.com/ethereum/eth-abi',
     include_package_data=True,
     install_requires=[
-        'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing>=2.0.0,<3.0.0',
+        'eth-utils>=2.0.0,<3.0.0',
+        'eth-typing>=3.0.0,<4.0.0',
         'parsimonious>=0.8.0,<0.9.0',
     ],
     python_requires='>=3.6, <4',


### PR DESCRIPTION
## What was wrong?
eth-typing and eth-utils had breaking change releases that needed to be pulled in here. 


## How was it fixed?
Bumped dependency requirements. 


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://kubrick.htvapps.com/htv-prod-media.s3.amazonaws.com/ibmig/cms/image/wesh/19221582-19221582.jpg?crop=1xw:0.84385896939170868xh;center,top&resize=900:*)
