### PR TITLE
Update mypy and add python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
         environment:
           TOXENV: docs
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
         environment:
           TOXENV: lint
   py36-core:

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -78,8 +78,8 @@ class BaseEncoder(BaseCoder, metaclass=abc.ABCMeta):
     def invalidate_value(
         cls,
         value: Any,
-        exc: Type[Exception]=EncodingTypeError,
-        msg: Optional[str]=None,
+        exc: Type[Exception] = EncodingTypeError,
+        msg: Optional[str] = None,
     ) -> None:
         """
         Throws a standard exception for when a value is not encodable by an

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -359,7 +359,7 @@ class ABIRegistry(Copyable, BaseRegistry):
         return coder
 
     @_clear_encoder_cache
-    def register_encoder(self, lookup: Lookup, encoder: Encoder, label: str=None) -> None:
+    def register_encoder(self, lookup: Lookup, encoder: Encoder, label: str = None) -> None:
         """
         Registers the given ``encoder`` under the given ``lookup``.  A unique
         string label may be optionally provided that can be used to refer to
@@ -380,7 +380,7 @@ class ABIRegistry(Copyable, BaseRegistry):
         self._unregister(self._encoders, lookup_or_label)
 
     @_clear_decoder_cache
-    def register_decoder(self, lookup: Lookup, decoder: Decoder, label: str=None) -> None:
+    def register_decoder(self, lookup: Lookup, decoder: Decoder, label: str = None) -> None:
         """
         Registers the given ``decoder`` under the given ``lookup``.  A unique
         string label may be optionally provided that can be used to refer to
@@ -400,7 +400,11 @@ class ABIRegistry(Copyable, BaseRegistry):
         """
         self._unregister(self._decoders, lookup_or_label)
 
-    def register(self, lookup: Lookup, encoder: Encoder, decoder: Decoder, label: str=None) -> None:
+    def register(self,
+                 lookup: Lookup,
+                 encoder: Encoder,
+                 decoder: Decoder,
+                 label: str = None) -> None:
         """
         Registers the given ``encoder`` and ``decoder`` under the given
         ``lookup``.  A unique string label may be optionally provided that can

--- a/eth_abi/tools/_strategies.py
+++ b/eth_abi/tools/_strategies.py
@@ -41,7 +41,7 @@ class StrategyRegistry(BaseRegistry):
     def register_strategy(self,
                           lookup: Lookup,
                           registration: StrategyRegistration,
-                          label: str=None) -> None:
+                          label: str = None) -> None:
         self._register(self._strategies, lookup, registration, label=label)
 
     def unregister_strategy(self, lookup_or_label: Lookup) -> None:

--- a/eth_abi/utils/string.py
+++ b/eth_abi/utils/string.py
@@ -3,7 +3,7 @@ from typing import (
 )
 
 
-def abbr(value: Any, limit: int=20) -> str:
+def abbr(value: Any, limit: int = 20) -> str:
     """
     Converts a value into its string representation and abbreviates that
     representation based on the given length `limit` if necessary.

--- a/newsfragments/155.feature.rst
+++ b/newsfragments/155.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.8. Includes updating mypy and flake8 version requirements

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
         HYPOTHESIS_REQUIREMENT,
     ],
     'lint': [
-        "flake8==3.4.1",
+        "flake8==4.0.1",
         "isort>=4.2.15,<5",
         "mypy==0.910",
         "pydocstyle>=3.0.0,<4",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
-        "mypy==0.701",
+        "mypy==0.910",
         "pydocstyle>=3.0.0,<4",
     ],
     'doc': [

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,6 @@ basepython=python
 extras=lint
 commands=
     mypy --follow-imports=silent -p eth_abi.utils --config-file {toxinidir}/mypy.ini
-    flake8 {toxinidir}/eth_abi {toxinidir}/tests
+    flake8 --ignore=W504 {toxinidir}/eth_abi {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_abi {toxinidir}/tests
     pydocstyle {toxinidir}/eth_abi {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?
Going through and updating support for libraries. Old mypy doesn't work with python 3.8 (`fails with error: AttributeError: 'FlakesChecker' object has no attribute 'CONSTANT'`).


## How was it fixed?
Updated mypy to the latest version and added tests for python 3.8. Also had to update flake8 as well. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.rd.com/wp-content/uploads/2021/04/GettyImages-1053735888-scaled.jpg)
