### PR TITLE
Drop python 3.6 support, add python 3.9 and 3.10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.10
         environment:
           TOXENV: docs
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.10
         environment:
           TOXENV: lint
   py37-core:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: lint
-  py36-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-core
   py37-core:
     <<: *common
     docker:
@@ -72,6 +66,5 @@ workflows:
     jobs:
       - docs
       - lint
-      - py36-core
       - py37-core
       - py38-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
 workflows:
   version: 2
   test:
@@ -68,3 +74,4 @@ workflows:
       - lint
       - py37-core
       - py38-core
+      - py39-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
 workflows:
   version: 2
   test:
@@ -75,3 +81,4 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core

--- a/newsfragments/156.feature.rst
+++ b/newsfragments/156.feature.rst
@@ -1,0 +1,1 @@
+Drop Python 3.6 support, add Python 3.9 and 3.10 support. Update any dependencies accordingly

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ extras_require = {
         HYPOTHESIS_REQUIREMENT,
     ],
     'test': [
-        "pytest==4.4.1",
+        "pytest>=6.2.5,<7",
         "pytest-pythonpath>=0.7.1",
-        "pytest-xdist==1.22.3",
+        "pytest-xdist>=2.5.0,<3",
         "tox>=2.9.1,<3",
         "eth-hash[pycryptodome]",
         HYPOTHESIS_REQUIREMENT,
@@ -84,5 +84,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'eth-typing>=3.0.0,<4.0.0',
         'parsimonious>=0.8.0,<0.9.0',
     ],
-    python_requires='>=3.6, <4',
+    python_requires='>=3.7, <4',
     extras_require=extras_require,
     py_modules=['eth_abi'],
     license="MIT",
@@ -81,7 +81,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38}-core
+    py{37,38,39}-core
     lint
     docs
 
@@ -28,6 +28,7 @@ basepython =
     docs: python
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 extras=
     test
     docs: doc

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38,39}-core
+    py{37,38,39,310}-core
     lint
     docs
 
@@ -29,6 +29,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 extras=
     test
     docs: doc

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37,38}-core
+    py{37,38}-core
     lint
     docs
 
@@ -26,7 +26,6 @@ commands=
     docs: make build-docs
 basepython =
     docs: python
-    py36: python3.6
     py37: python3.7
     py38: python3.8
 extras=


### PR DESCRIPTION
## What was wrong?
Python 3.6 is no longer officially supported, so dropped that. Added support for more modern pythons - 3.9 & 3.10. 


## How was it fixed?
Added CI runs for 3.9, and 3.10. Removed CI runs for 3.6. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cloudfront-eu-central-1.images.arcpublishing.com/thenational/RJAZRPZTEK2JJPSUNMI5P7MWEE.jpg)
