### PR TITLE
Remove venv files from being packaged with sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude * venv*

--- a/newsfragments/168.misc.rst
+++ b/newsfragments/168.misc.rst
@@ -1,0 +1,1 @@
+Remove venv files from being packaged in ``dist/``


### PR DESCRIPTION
## What was wrong?
venv* files were getting packaged up with the `dist`

see ethereum/eth-account#150

## How was it fixed?

Added a `recursive-exclude` in `MANIFEST.in` for the venv files. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/wrwmxfhr3wl11.jpg?width=960&crop=smart&auto=webp&s=534b665c720189d07f101782a30cad61c6ac3a40)
