### PR TITLE
Add make notes command, exclude venv in MANIFEST and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
-venv
+venv*
 
 # Installer logs
 pip-log.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude * venv*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-recursive-exclude * venv*
+prune venv*

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,12 @@ docs: build-docs
 linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
-notes:
+check-bump:
+ifndef bump
+	$(error bump must be set, typically: major, minor, patch, or devnum)
+endif
+
+notes: check-bump
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
@@ -59,7 +64,7 @@ notes:
 	make build-docs
 	git commit -m "Compile release notes"
 
-release: clean
+release: check-bump clean
 	# require that you be on a branch that's linked to upstream/master
 	git status -s -b | head -1 | grep "\.\.upstream/master"
 	# verify that docs build correctly

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@echo "test - run tests quickly with the default Python"
 	@echo "testall - run tests on every Python version with tox"
 	@echo "release - package and upload a release"
-	@echo "sdist - package"
+	@echo "dist - package"
 
 clean: clean-build clean-pyc
 
@@ -31,7 +31,7 @@ lint-roll:
 	$(MAKE) lint
 
 test:
-	py.test tests
+	pytest tests
 
 test-all:
 	tox
@@ -40,6 +40,9 @@ build-docs:
 	sphinx-apidoc -o docs/ . setup.py 'eth_abi/utils/*' 'eth_abi/tools/*' 'tests/*'
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+	$(MAKE) -C docs doctest
+	./newsfragments/validate_files.py
+	towncrier --draft --version preview
 
 docs: build-docs
 	open docs/_build/html/index.html
@@ -47,7 +50,22 @@ docs: build-docs
 linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
+notes:
+	# Let UPCOMING_VERSION be the version that is used for the current bump
+	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
+	# Now generate the release notes to have them included in the release commit
+	towncrier --yes --version $(UPCOMING_VERSION)
+	# Before we bump the version, make sure that the towncrier-generated docs will build
+	make build-docs
+	git commit -m "Compile release notes"
+
 release: clean
+	# require that you be on a branch that's linked to upstream/master
+	git status -s -b | head -1 | grep "\.\.upstream/master"
+	# verify that docs build correctly
+	./newsfragments/validate_files.py is-empty
+	make build-docs
+	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
@@ -55,6 +73,6 @@ release: clean
 	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
-sdist: clean
+dist: clean
 	python setup.py sdist bdist_wheel
 	ls -l dist

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,8 @@ import os
 DIR = os.path.dirname('__file__')
 with open (os.path.join(DIR, '../setup.py'), 'r') as f:
     for line in f:
-        if 'version=' in line:
-            setup_version = line.split('\'')[1]
+        if "version=" in line:
+            setup_version = line.split('"')[1]
             break
 
 # -- General configuration ------------------------------------------------

--- a/newsfragments/172.misc.rst
+++ b/newsfragments/172.misc.rst
@@ -1,0 +1,1 @@
+Exclude venv files from git tracking, and from getting put into dist/. Add ``make notes`` command to Makefile, and add some checks

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ from setuptools import (
 HYPOTHESIS_REQUIREMENT = "hypothesis>=4.18.2,<5.0.0"
 
 extras_require = {
-    'tools': [
+    "tools": [
         HYPOTHESIS_REQUIREMENT,
     ],
-    'test': [
+    "test": [
         "pytest==4.4.1",
         "pytest-pythonpath>=0.7.1",
         "pytest-xdist==1.22.3",
@@ -19,19 +19,19 @@ extras_require = {
         "eth-hash[pycryptodome]",
         HYPOTHESIS_REQUIREMENT,
     ],
-    'lint': [
+    "lint": [
         "flake8==4.0.1",
         "isort>=4.2.15,<5",
         "mypy==0.910",
         "pydocstyle>=3.0.0,<4",
     ],
-    'doc': [
+    "doc": [
         "Sphinx>=1.6.5,<2",
         "jinja2>=3.0.0,<3.1.0",  # jinja2<3.0 or >=3.1.0 cause doc build failures.
         "sphinx_rtd_theme>=0.1.9",
-        "towncrier==18.5.0",  # towncrier doesn't follow semver
+        "towncrier>=21,<22",
     ],
-    'dev': [
+    "dev": [
         "bumpversion>=0.5.3,<1",
         "pytest-watch>=4.1.0,<5",
         "wheel",
@@ -40,50 +40,50 @@ extras_require = {
     ],
 }
 
-extras_require['dev'] = (
-    extras_require['dev'] +  # noqa: W504
-    extras_require['test'] +  # noqa: W504
-    extras_require['lint'] +  # noqa: W504
-    extras_require['doc']
+extras_require["dev"] = (
+    extras_require["dev"]
+    + extras_require["test"]  # noqa: W504
+    + extras_require["lint"]  # noqa: W504
+    + extras_require["doc"]  # noqa: W504
 )
 
 
-with open('./README.md') as readme:
+with open("./README.md") as readme:
     long_description = readme.read()
 
 
 setup(
-    name='eth_abi',
+    name="eth_abi",
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
-    version='2.1.1',
+    version="2.1.1",
     description="""eth_abi: Python utilities for working with Ethereum ABI definitions, especially encoding and decoding""",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='The Ethereum Foundation',
-    author_email='snakecharmers@ethereum.org',
-    url='https://github.com/ethereum/eth-abi',
+    long_description_content_type="text/markdown",
+    author="The Ethereum Foundation",
+    author_email="snakecharmers@ethereum.org",
+    url="https://github.com/ethereum/eth-abi",
     include_package_data=True,
     install_requires=[
-        'eth-utils>=1.2.0,<2.0.0',
-        'eth-typing>=2.0.0,<3.0.0',
-        'parsimonious>=0.8.0,<0.9.0',
+        "eth-utils>=1.2.0,<2.0.0",
+        "eth-typing>=2.0.0,<3.0.0",
+        "parsimonious>=0.8.0,<0.9.0",
     ],
-    python_requires='>=3.6, <4',
+    python_requires=">=3.6, <4",
     extras_require=extras_require,
-    py_modules=['eth_abi'],
+    py_modules=["eth_abi"],
     license="MIT",
     zip_safe=False,
-    keywords='ethereum',
+    keywords="ethereum",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={'eth_abi': ['py.typed']},
+    package_data={"eth_abi": ["py.typed"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )


### PR DESCRIPTION
## What was wrong?
I noticed a few things when I was trying to release v2.x.
- There was no `make notes` command to compile release notes
- venv files weren't being gitignored
- venv files had the potential to make their way into the dist

## How was it fixed?
- Added a few commands to the Makefile.
- added venvs to .gitignore
- added venv files to be excluded in the MANIFEST.in

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallpaperaccess.com/full/83858.jpg)
