### PR TITLE
[v3] reduce truncation in errors (#166)

### DIFF
--- a/eth_abi/utils/string.py
+++ b/eth_abi/utils/string.py
@@ -3,7 +3,7 @@ from typing import (
 )
 
 
-def abbr(value: Any, limit: int = 20) -> str:
+def abbr(value: Any, limit: int = 79) -> str:
     """
     Converts a value into its string representation and abbreviates that
     representation based on the given length `limit` if necessary.

--- a/newsfragments/166.misc.rst
+++ b/newsfragments/166.misc.rst
@@ -1,0 +1,1 @@
+Reduce truncation in errors

--- a/tests/utils/test_abbr.py
+++ b/tests/utils/test_abbr.py
@@ -6,16 +6,23 @@ from eth_abi.utils.string import (
 
 
 @pytest.mark.parametrize(
-    'value,expected,limit',
+    "value,expected,limit",
     (
-        (1234567891234567891, '1234567891234567891', None),
-        (12345678912345678912, '12345678912345678912', None),
-        (123456789123456789123, '12345678912345678...', None),
-        ('asdf' * 30, "'asdfasdfasdfasdf...", None),
-        (list(range(100)), '[0, 1, 2, 3, 4, 5...', None),
-        (1234567891234567891, '...', 3),
-        (1234567891234567891, '1...', 4),
-    )
+        (1234567891234567891, "1234567891234567891", None),
+        (12345678912345678912, "12345678912345678912", None),
+        (
+            "asdf" * 30,
+            "'asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasd...",
+            None,
+        ),
+        (
+            list(range(100)),
+            "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 2...",  # noqa: E501
+            None,
+        ),
+        (1234567891234567891, "...", 3),
+        (1234567891234567891, "1...", 4),
+    ),
 )
 def test_abbr(value, expected, limit):
     if limit is not None:
@@ -27,4 +34,4 @@ def test_abbr(value, expected, limit):
 
 def test_abbr_throws_value_errors():
     with pytest.raises(ValueError):
-        abbr('asdf', limit=2)
+        abbr("asdf", limit=2)


### PR DESCRIPTION
* reduce truncation in errors

allow more int values to be fully printed in errors. the current code
truncates a lot of integer values which fit in 256 bits, which reduces
helpfulness of the error message when debugging.

* Fix tests, remove one that was a duplicate test of logic

* Add newsfragment

Co-authored-by: kclowes <kclowes@users.noreply.github.com>

## What was wrong?

v3 back port of #166


## How was it fixed?

Increased the default value of truncation from 20 -> 79.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/564x/f7/f6/98/f7f6981a1e64c24d1f52544d58530dd4.jpg)
