### PR TITLE
Ignore black revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ignore commit that added black to the codebase
+8938d21ceb8300f38391cb3a27ef554c2657b0f9

--- a/newsfragments/178.misc.rst
+++ b/newsfragments/178.misc.rst
@@ -1,0 +1,1 @@
+Add ``black`` SHA to ``.git-blame-ignore-revs``


### PR DESCRIPTION
## What was wrong?
Git blame gets clobbered after adding black linting to a codebase. This will ignore that SHA in git blame. 

## How was it fixed?

Added `.git-blame-ignore-revs` file and the SHA that added `black`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://a-z-animals.com/media/Shih-Tzu-Canis-familiaris-running.jpg)