### PR TITLE
Add black check instead of running black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,5 +43,5 @@ commands=
     mypy --follow-imports=silent -p eth_abi.utils --config-file {toxinidir}/mypy.ini
     flake8 --extend-ignore=W504,E203,W503 {toxinidir}/eth_abi {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_abi {toxinidir}/tests
-    black eth_abi/ tests/
+    black eth_abi/ tests/ --check
     pydocstyle {toxinidir}/eth_abi {toxinidir}/tests --add-ignore=D415


### PR DESCRIPTION
## What was wrong?

forgot to add the `--check` flag to the black command on CI.


## How was it fixed?

Added it!

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://bestlifeonline.com/wp-content/uploads/sites/3/2018/10/bernese-puppy-swing.jpg?quality=82&strip=all)
