### PR TITLE
Add black SHA from master

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ignore SHAs that added black
+cfb3711ac242c33ec229ffb0255555d7de696425

--- a/newsfragments/183.misc.rst
+++ b/newsfragments/183.misc.rst
@@ -1,0 +1,1 @@
+Ignore SHA that added ``black`` linting in git blame


### PR DESCRIPTION
## What was wrong?
Need to not clobber git blame.


## How was it fixed?

Added SHA that added black to `.git-blame-ignore-revs`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallpaperaccess.com/full/472834.jpg)
