### PR TITLE
fix change log link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,1 @@
-See `docs/releases.rst`.
+See `docs/release_notes.rst`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Python utilities for working with Ethereum ABI definitions, especially encoding and decoding
 
-Read more in the [documentation on ReadTheDocs](https://eth-abi.readthedocs.io/). [View the change log](https://eth-abi.readthedocs.io/en/latest/releases.html).
+Read more in the [documentation on ReadTheDocs](https://eth-abi.readthedocs.io/). [View the change log](https://eth-abi.readthedocs.io/en/latest/release_notes.html).
 
 ## Quickstart
 

--- a/newsfragments/186.misc.rst
+++ b/newsfragments/186.misc.rst
@@ -1,0 +1,1 @@
+fix change log link


### PR DESCRIPTION
## What was wrong?

The link to the change log in the README was wrong (releases vs. release_notes).

## How was it fixed?

I fixed it in `CHANGELOG` and `README.md`. No further appearances were found.

### To-Do

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/188741867-f480e5ec-d96c-4208-a801-d2e938e356f7.png)
