### PR TITLE
fix: decode malformed strings

### DIFF
--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -121,7 +121,11 @@ class ABIDecoder(BaseABICoder):
 
     stream_class = ContextFramesBytesIO
 
-    def decode(self, types: Iterable[TypeStr], data: Decodable) -> Tuple[Any, ...]:
+    def decode(
+        self,
+        types: Iterable[TypeStr],
+        data: Decodable,
+    ) -> Tuple[Any, ...]:
         """
         Decodes the binary value ``data`` as a sequence of values of the ABI types
         in ``types`` via the head-tail mechanism into a tuple of equivalent python

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -17,7 +17,6 @@ from eth_abi.base import (
     parse_type_str,
 )
 from eth_abi.exceptions import (
-    DecodingError,
     InsufficientDataBytes,
     NonEmptyPaddingBytes,
 )
@@ -548,18 +547,4 @@ class StringDecoder(ByteStringDecoder):
 
     @staticmethod
     def decoder_fn(data):
-        try:
-            value = data.decode("utf-8")
-        except UnicodeDecodeError as e:
-            raise DecodingError(
-                e.encoding,
-                e.object,
-                e.start,
-                e.end,
-                "The returned type for this function is string which is "
-                "expected to be a UTF8 encoded string of text. The returned "
-                "value could not be decoded as valid UTF8. This is indicative "
-                "of a broken application which is using incorrect return types for "
-                "binary data.",
-            ) from e
-        return value
+        return data.decode("utf-8", errors="surrogateescape")

--- a/newsfragments/187.feature.rst
+++ b/newsfragments/187.feature.rst
@@ -1,0 +1,1 @@
+updated `StringDecoder` class to allow user-defined handling of malformed strings, handle with `strict` by default


### PR DESCRIPTION
## What was wrong?

decoding was failing for some malformed strings.

you can see an example of this if you try to decode logs from mainnet transaction `0x505870232ebd6cefd2a59c760924664212f72759e58fd2df82d61b67ffe0dd75`.

it should be possible to read the useful data even from a malformed input.

## How was it fixed?

added `errors="surrogateescape"` to `decode` as suggested here https://peps.python.org/pep-0383/

i deliberately skipped adding the same to `encode` because passing an unencodable string usually signifies a user error.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![out-3-2](https://user-images.githubusercontent.com/4562643/186795852-0889469f-577e-425c-96a3-abefc651b475.png)
