### PR TITLE
fix: the zero-length bytestring encoding

### DIFF
--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -528,6 +528,10 @@ class ByteStringEncoder(BaseEncoder):
         value_length = len(value)
 
         encoded_size = encode_uint_256(value_length)
+
+        if value_length == 0:
+            return encoded_size
+
         padded_value = zpad_right(value, ceil32(value_length))
 
         return encoded_size + padded_value


### PR DESCRIPTION
## What was wrong?

When the length of the byte string is 0, there is zero-bytes after the encoded length.

### Example

```js
// SPDX-License-Identifier: UNLICENSED
pragma solidity 0.8.15;

contract Test {
    function test() public pure returns (bytes memory) {
        bytes memory btest = '';
        bytes memory serialized = abi.encode(btest);
        return serialized;
        // 0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000
    }
}
```

```py
>>> import eth_abi
>>> eth_abi.encode(['bytes'], [b'']).hex()
'000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
# 32 bytes longer than the result given by abi.encode() in solidity
```

## How was it fixed?

Only return the `encoded_size` when `value_length` is zero.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/52900008/191534979-5871adc5-f2a2-4d68-87aa-191f54758a47.jpg)
