### PR TITLE
[WIP] ``encode()`` & ``decode()`` array types as python ``list`` only.

### DIFF
--- a/docs/grammar.rst
+++ b/docs/grammar.rst
@@ -36,7 +36,7 @@ and do various operations with the results:
     >>> len(tuple_type.components)
     4
     >>> tuple_type.arrlist
-    ((2,),)
+    ([2],)
     >>> int_type.base, int_type.sub, int_type.arrlist
     ('int', 256, None)
     >>> bytes_type.base, bytes_type.sub, bytes_type.arrlist
@@ -44,7 +44,7 @@ and do various operations with the results:
     >>> ufixed_type.base, ufixed_type.sub, ufixed_type.arrlist
     ('ufixed', (128, 18), None)
     >>> bool_type.base, bool_type.sub, bool_type.arrlist
-    ('bool', None, ((),))
+    ('bool', None, ([],))
 
     >>> # Checking for arrays or dynamicism
     >>> tuple_type.is_array, tuple_type.is_dynamic

--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -70,7 +70,7 @@ class ABIEncoder(BaseABICoder):
 
         encoder = TupleEncoder(encoders=encoders)
 
-        return encoder(args)
+        return encoder(tuple(args))
 
     def is_encodable(self, typ: TypeStr, arg: Any) -> bool:
         """

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -7,6 +7,7 @@ from typing import (
 
 from eth_utils import (
     big_endian_to_int,
+    to_list,
     to_normalized_address,
     to_tuple,
 )
@@ -252,7 +253,7 @@ class SizedArrayDecoder(BaseArrayDecoder):
 
         self.is_dynamic = self.item_decoder.is_dynamic
 
-    @to_tuple
+    @to_list
     def decode(self, stream):
         for _ in range(self.array_size):
             yield self.item_decoder(stream)
@@ -262,7 +263,7 @@ class DynamicArrayDecoder(BaseArrayDecoder):
     # Dynamic arrays are always dynamic, regardless of their elements
     is_dynamic = True
 
-    @to_tuple
+    @to_list
     def decode(self, stream):
         array_size = decode_uint_256(stream)
         stream.push_frame(32)

--- a/eth_abi/encoding.py
+++ b/eth_abi/encoding.py
@@ -16,7 +16,6 @@ from eth_utils import (
     is_boolean,
     is_bytes,
     is_integer,
-    is_list_like,
     is_number,
     is_text,
     to_canonical_address,
@@ -114,10 +113,10 @@ class TupleEncoder(BaseEncoder):
             raise ValueError("`encoders` may not be none")
 
     def validate_value(self, value):
-        if not is_list_like(value):
+        if not isinstance(value, tuple):
             self.invalidate_value(
                 value,
-                msg="must be list-like object such as array or tuple",
+                msg="`value` type expected as python `tuple`.",
             )
 
         if len(value) != len(self.encoders):
@@ -590,10 +589,10 @@ class BaseArrayEncoder(BaseEncoder):
             raise ValueError("`item_encoder` may not be none")
 
     def validate_value(self, value):
-        if not is_list_like(value):
+        if not isinstance(value, list):
             self.invalidate_value(
                 value,
-                msg="must be list-like such as array or tuple",
+                msg="`value` type expected as python `list`.",
             )
 
         for item in value:

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -83,10 +83,10 @@ class NodeVisitor(parsimonious.NodeVisitor):
         # Ignore left and right brackets
         _, int_value, _ = visited_children
 
-        return (int_value,)
+        return [int_value]
 
     def visit_dynam_arr(self, node, visited_children):
-        return tuple()
+        return list()
 
     def visit_alphas(self, node, visited_children):
         return node.text
@@ -119,6 +119,9 @@ class NodeVisitor(parsimonious.NodeVisitor):
         :returns: An instance of :class:`~eth_abi.grammar.ABIType` containing
             information about the parsed type string.
         """
+        if type_str == "[]":
+            raise ParseError("empty python `list` does not map to an ABI type.")
+
         if not isinstance(type_str, str):
             raise TypeError(
                 "Can only parse string values: got {}".format(type(type_str))

--- a/tests/abi/test_decode.py
+++ b/tests/abi/test_decode.py
@@ -47,10 +47,6 @@ def test_abi_decode_for_single_static_types(type_str, expected, abi_encoding, _)
     CORRECT_DYNAMIC_ENCODINGS,
 )
 def test_abi_decode_for_single_dynamic_types(type_str, expected, abi_encoding, _):
-    # Tests set up list values but encoders return sequences as tuples.
-    # i.e. [b'\xde\xad\xbe\xef'] vs encoder return type (b'\xde\xad\xbe\xef',)
-    expected = tuple(expected) if isinstance(expected, list) else expected
-
     abi_encoding = (
         # 32 bytes offset for dynamic types
         b"".join([words("20"), abi_encoding])

--- a/tests/common/strategies.py
+++ b/tests/common/strategies.py
@@ -60,8 +60,8 @@ non_array_type_strs = st.one_of(
     fixed_type_strs,
 )
 
-dynam_array_components = st.just(tuple())
-fixed_array_components = st.integers(min_value=1).map(lambda x: (x,))
+dynam_array_components = st.just(list())
+fixed_array_components = st.integers(min_value=1).map(lambda x: [x])
 array_components = st.one_of(dynam_array_components, fixed_array_components)
 
 array_lists = st.lists(array_components, min_size=1, max_size=6)
@@ -209,7 +209,7 @@ unsized_array_strs_values = num_unsized_elements.flatmap(
         [
             st.tuples(
                 type_strs.map("{}[]".format),
-                st.lists(type_values, min_size=n, max_size=n).map(tuple),
+                st.lists(type_values, min_size=n, max_size=n),
             )
             for type_strs, type_values in non_array
         ]
@@ -222,7 +222,7 @@ sized_array_strs_values = num_sized_elements.flatmap(
         [
             st.tuples(
                 type_strs.map(lambda ts: "{}[{}]".format(ts, n)),
-                st.lists(type_values, min_size=n, max_size=n).map(tuple),
+                st.lists(type_values, min_size=n, max_size=n),
             )
             for type_strs, type_values in non_array
         ]

--- a/tests/common/unit.py
+++ b/tests/common/unit.py
@@ -129,141 +129,141 @@ CORRECT_DYNAMIC_TUPLE_ENCODINGS = [
     # tuple w/ empty dynamic arrays
     (
         "(string[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(bytes[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(bytes32[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(address[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(int[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(uint[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(uint8[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     (
         "(uint256[])",
-        ((),),
+        ([],),
         words("20", "0"),
         b"",
     ),
     # nested tuple w/ empty dynamic arrays
     (
         "((string[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     (
         "((bytes[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     (
         "((bytes32[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     (
         "((address[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     (
         "((int[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     (
         "((uint8[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     (
         "((uint256[]))",
-        (((),),),
+        (([],),),
         words("20", "20", "0"),
         b"",
     ),
     # sanity check / consistency - doubly nested tuples with empty dynamic array
     (
         "(((string[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(((bytes[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(((bytes32[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(((address[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(((int[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(((uint8[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(((uint256[])))",
-        ((((),),),),
+        ((([],),),),
         words("20", "20", "20", "0"),
         b"",
     ),
     (
         "(bytes32[])",
-        ((zpad32_right(b"a"), zpad32_right(b"b")),),
+        ([zpad32_right(b"a"), zpad32_right(b"b")],),
         words("20", "2", "61>0", "62>0"),
         words("61>0", "62>0"),
     ),
@@ -275,13 +275,13 @@ CORRECT_DYNAMIC_TUPLE_ENCODINGS = [
     ),
     (
         "(int,(int,int[]))",
-        (1, (2, (3, 3))),
+        (1, (2, [3, 3])),
         words("1", "40", "2", "40", "2", "3", "3"),
         words("1", "2", "3", "3"),
     ),
     (
         "((int[],int),int)",
-        (((1, 1), 2), 3),
+        (([1, 1], 2), 3),
         words("40", "3", "40", "2", "2", "1", "1"),
         words("1", "1", "2", "3"),
     ),
@@ -310,7 +310,7 @@ CORRECT_DYNAMIC_TUPLE_ENCODINGS = [
     # Tuple arrays
     (
         "((int,int)[])",
-        (((1, 2), (3, 4)),),
+        ([(1, 2), (3, 4)],),
         words("20", "2", "1", "2", "3", "4"),
         words("1", "2", "3", "4"),
     ),
@@ -319,8 +319,8 @@ CORRECT_DYNAMIC_TUPLE_ENCODINGS = [
         (
             (
                 1,
-                (2, 3),
-                ((4, 5), (6, 7)),
+                [2, 3],
+                [(4, 5), (6, 7)],
             ),
             (8, 9),
             10,
@@ -346,11 +346,11 @@ CORRECT_DYNAMIC_TUPLE_ENCODINGS = [
     ),
     (
         "(int,int)[][]",
-        (
-            ((1, 2),),
-            ((3, 4), (5, 6)),
-            ((7, 8), (9, 10), (11, 12)),
-        ),
+        [
+            [(1, 2)],
+            [(3, 4), (5, 6)],
+            [(7, 8), (9, 10), (11, 12)],
+        ],
         words(
             "3",  # size of outer dynamic list
             "60",  # offset of first dynamic list
@@ -376,12 +376,7 @@ CORRECT_DYNAMIC_TUPLE_ENCODINGS = [
     ),
     (
         "((int,int)[][2])",
-        (
-            (
-                ((1, 2), (3, 4)),
-                ((5, 6), (7, 8), (9, 10)),
-            ),
-        ),
+        (([[(1, 2), (3, 4)], [(5, 6), (7, 8), (9, 10)]]),),
         words(
             "20",  # offset of constant size array
             "40",  # offset of first dynamic list of tuples
@@ -568,6 +563,14 @@ NOT_ENCODABLE = [
     ("int", True),
     ("bytes", 129),
     ("fixed8x1", 0.1),  # only Decimal and int are allowed
+    # `tuple` instead of `list` / `list` instead of `tuple`
+    ("string[]", ("shall", "not", "pass")),
+    ("bytes[]", (b"shall", b"not", b"pass")),
+    ("uint256[]", (1, 2, 3)),
+    ("()", []),
+    ("(string,string,string)", ["shall", "not", "pass"]),
+    ("(bytes,bytes,bytes)", [b"shall", b"not", b"pass"]),
+    ("(uint256,uint256,uint256)", [1, 2, 3]),
     # List size mismatch
     ("int[3]", (6, 2)),
     # Bytes string is wrong size

--- a/tests/decoding/test_decoder_properties.py
+++ b/tests/decoding/test_decoder_properties.py
@@ -380,7 +380,7 @@ def test_decode_address(address_bytes, padding_size, data_byte_size):
         st.integers(min_value=0, max_value=TT256M1),
         min_size=0,
         max_size=64,
-    ).map(tuple),
+    ),
 )
 def test_decode_array_of_unsigned_integers(array_size, array_values):
     size_bytes = zpad32(int_to_big_endian(array_size))


### PR DESCRIPTION
## What was wrong?

Issue #192

## How was it fixed?

- Python ``list`` types are expected for encoding solidity arrays and will be validated as such.
- Python ``tuple`` types are now reserved only for solidity structs, thus python ``list`` types will not be accepted as structs.

Summary of approach.

### To-Do

- [ ] Clean up commit history

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
