### PR TITLE
➕ Python 3.11 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .hypothesis
@@ -39,39 +39,45 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: docs
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: lint
   py37-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-core
   py38-core:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-core
   py39-core:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-core
   py310-core:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
+  py311-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-core
 workflows:
   version: 2
   test:
@@ -82,3 +88,4 @@ workflows:
       - py38-core
       - py39-core
       - py310-core
+      - py311-core

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -109,7 +109,7 @@ class NodeVisitor(parsimonious.NodeVisitor):
         return tuple(visited_children)
 
     @functools.lru_cache(maxsize=None)
-    def parse(self, type_str):
+    def parse(self, type_str, **kwargs):
         """
         Parses a type string into an appropriate instance of
         :class:`~eth_abi.grammar.ABIType`.  If a type string cannot be parsed,
@@ -125,7 +125,7 @@ class NodeVisitor(parsimonious.NodeVisitor):
             )
 
         try:
-            return super().parse(type_str)
+            return super().parse(type_str, **kwargs)
         except parsimonious.ParseError as e:
             raise ParseError(e.text, e.pos, e.expr)
 

--- a/newsfragments/194.feature.rst
+++ b/newsfragments/194.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.11

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ setup(
     url="https://github.com/ethereum/eth-abi",
     include_package_data=True,
     install_requires=[
-        "eth-utils>=2.0.0,<3.0.0",
-        "eth-typing>=3.0.0,<4.0.0",
+        "eth-utils>=2.0.0",
+        "eth-typing>=3.0.0",
         "parsimonious>=0.8.0,<0.10.0",
     ],
     python_requires=">=3.7, <4",

--- a/setup.py
+++ b/setup.py
@@ -67,8 +67,7 @@ setup(
     install_requires=[
         "eth-utils>=2.0.0,<3.0.0",
         "eth-typing>=3.0.0,<4.0.0",
-        "parsimonious>=0.8.0,<0.9.0; python_version < '3.11'",
-        "parsimonious>=0.9.0; python_version >= '3.11'",
+        "parsimonious>=0.8.0,<0.10.0",
     ],
     python_requires=">=3.7, <4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
     install_requires=[
         "eth-utils>=2.0.0,<3.0.0",
         "eth-typing>=3.0.0,<4.0.0",
-        "parsimonious>=0.8.0,<0.9.0",
+        "parsimonious>=0.8.0,<0.9.0; python_version < '3.11'",
+        "parsimonious>=0.9.0; python_version >= '3.11'",
     ],
     python_requires=">=3.7, <4",
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38,39,310}-core
+    py{37,38,39,310,311}-core
     lint
     docs
 
@@ -30,6 +30,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 extras=
     test
     docs: doc


### PR DESCRIPTION
## What was wrong?

- Need `eth-abi` Python 3.11 support to be able to support Python 3.11 upstream: ethereum/eth-account#160

## How was it fixed?

- Update `parsimonious` upper bound to `0.9.0`
- Added circleci tests for Python 3.11

### To-Do

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/02/9f/e6/029fe6d3a667f97d71a20ae43c1ddcd3.jpg)
