### PR TITLE
Remove venv files from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,5 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-recursive-exclude * venv*
+
+prune venv*

--- a/newsfragments/196.misc.rst
+++ b/newsfragments/196.misc.rst
@@ -1,0 +1,1 @@
+Prune correct virtual environment files


### PR DESCRIPTION
## What was wrong?

the `exclude` line in the MANIFEST.in wasn't doing the right thing. 

## How was it fixed?

Added the correct command to prune virtualenv files from the dist.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://image.shutterstock.com/image-photo/brown-bear-cub-playing-on-260nw-1402804583.jpg)
