### PR TITLE
Update Parsimonious dependency to >=0.9.0,<0.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,12 +42,66 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: docs
-  lint:
+  py37-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.7
+        environment:
+          TOXENV: py37-lint
+  py38-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-lint
+  py39-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.9
+        environment:
+          TOXENV: py39-lint
+  py310-lint:
     <<: *common
     docker:
       - image: cimg/python:3.10
         environment:
-          TOXENV: lint
+          TOXENV: py310-lint
+  py311-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-lint
+  py37-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.7
+        environment:
+          TOXENV: py37-wheel
+  py38-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-wheel
+  py39-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.9
+        environment:
+          TOXENV: py39-wheel
+  py310-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.10
+        environment:
+          TOXENV: py310-wheel
+  py311-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-wheel
   py37-core:
     <<: *common
     docker:
@@ -83,7 +137,16 @@ workflows:
   test:
     jobs:
       - docs
-      - lint
+      - py37-lint
+      - py38-lint
+      - py39-lint
+      - py310-lint
+      - py311-lint
+      - py37-wheel
+      - py38-wheel
+      - py39-wheel
+      - py310-wheel
+      - py311-wheel
       - py37-core
       - py38-core
       - py39-core

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	tox -elint
+	tox -e lint
 
 lint-roll:
 	isort --recursive eth_abi tests

--- a/newsfragments/201.breaking-change.rst
+++ b/newsfragments/201.breaking-change.rst
@@ -1,0 +1,1 @@
+Upgrade Parsimonious dependency to allow >=0.9,<0.10

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
         HYPOTHESIS_REQUIREMENT,
     ],
     "lint": [
-        "flake8==4.0.1",
+        "flake8",
         "isort>=4.2.15,<5",
         "mypy==0.910",
         "pydocstyle>=6.0.0,<7",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         "eth-utils>=2.0.0",
         "eth-typing>=3.0.0",
-        "parsimonious>=0.8.0,<0.10.0",
+        "parsimonious>=0.9.0,<0.10.0",
     ],
     python_requires=">=3.7, <4",
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ extras=
 allowlist_externals=make
 passenv=PYTEST_ADDOPTS
 
-[testenv:py{37,38,39,310,311}-lint]
+[common-lint]
 extras=dev
 commands=
     mypy --follow-imports=silent -p eth_abi.utils --config-file {toxinidir}/mypy.ini
@@ -46,6 +46,11 @@ commands=
     isort --recursive --check-only --diff {toxinidir}/eth_abi {toxinidir}/tests
     black eth_abi/ tests/ setup.py --check
     pydocstyle {toxinidir}/eth_abi {toxinidir}/tests --add-ignore=D415
+
+
+[testenv:py{37,38,39,310,311}-lint]
+extras: {[common-lint]extras}
+commands: {[common-lint]commands}
 
 [testenv:py{37,38,39,310,311}-wheel]
 basepython=

--- a/tox.ini
+++ b/tox.ini
@@ -47,10 +47,14 @@ commands=
     black eth_abi/ tests/ setup.py --check
     pydocstyle {toxinidir}/eth_abi {toxinidir}/tests --add-ignore=D415
 
+[testenv:lint]
+basepython=python
+extras=lint
+commands={[common-lint]commands}
 
 [testenv:py{37,38,39,310,311}-lint]
-extras: {[common-lint]extras}
-commands: {[common-lint]commands}
+extras={[common-lint]extras}
+commands={[common-lint]commands}
 
 [testenv:py{37,38,39,310,311}-wheel]
 basepython=

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist=
     py{37,38,39,310,311}-core
-    lint
+    py{37,38,39,310,311}-wheel
+    py{37,38,39,310,311}-lint
     docs
 
 [isort]
@@ -34,15 +35,35 @@ basepython =
 extras=
     test
     docs: doc
-whitelist_externals=make
+allowlist_externals=make
 passenv=PYTEST_ADDOPTS
 
-[testenv:lint]
-basepython=python
-extras=lint
+[testenv:py{37,38,39,310,311}-lint]
+extras=dev
 commands=
     mypy --follow-imports=silent -p eth_abi.utils --config-file {toxinidir}/mypy.ini
     flake8 --extend-ignore=W504,E203,W503 {toxinidir}/eth_abi {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/eth_abi {toxinidir}/tests
     black eth_abi/ tests/ setup.py --check
     pydocstyle {toxinidir}/eth_abi {toxinidir}/tests --add-ignore=D415
+
+[testenv:py{37,38,39,310,311}-wheel]
+basepython=
+    py37: python3.7
+    py38: python3.8
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+deps=
+    wheel
+    build
+allowlist_externals=
+    /bin/rm
+    /bin/bash
+commands=
+    pip install --upgrade pip
+    /bin/rm -rf build dist
+    python setup.py sdist bdist_wheel
+    /bin/bash -c 'pip install --upgrade "$(ls dist/eth_abi-*-py3-none-any.whl)" --progress-bar off'
+    python -c "from eth_abi import encode"
+skip_install=true


### PR DESCRIPTION
## What was wrong?

Parsimonious<0.9 was incompatible with Python 3.11. 

Closes #195 

## How was it fixed?

Added smoke tests for all supported Python versions for both lint (dev dependencies) and wheel tests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

[//]: # (See: https://eth-abi.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://bouncymustard.com/wp-content/uploads/2022/03/share-cute-animals-ready-for-spring.jpg)
