### PR TITLE
update tox install and usage in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,12 @@ common: &common
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: python -m pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
-        command: python -m tox -r
+        command: python -m tox run -r
     - save_cache:
         paths:
           - .hypothesis
@@ -50,10 +52,12 @@ windows_steps: &windows_steps
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: python -m pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
-        command: python -m tox -r
+        command: python -m tox run -r
     - save_cache:
         paths:
           - .tox

--- a/newsfragments/208.internal.rst
+++ b/newsfragments/208.internal.rst
@@ -1,0 +1,1 @@
+Updated CI process to handle tox issue caused by `virtualenv` update


### PR DESCRIPTION
### What was wrong?

`virtualenv` updates broke our CI setup. 

### How was it fixed?

This pulls the fix as done in the template [here](https://github.com/ethereum/ethereum-python-project-template/pull/85)

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-abi/assets/5199899/8f663a7a-4726-448d-b597-accfd9e7e065)