### PR TITLE
allow decoding byte string without padding

### DIFF
--- a/docs/decoding.rst
+++ b/docs/decoding.rst
@@ -29,3 +29,32 @@ The :py:meth:`eth_abi.decoding.BaseDecoder.decode` function provides an API for
 decoding binary values for ABI types into python values. It accepts a sequence of
 ABI type strings as the first argument and the binary data to be decoded, as a python
 ``bytes`` or ``bytearray`` value, as the second argument.
+
+Strict Mode
+-----------
+
+By default, the decoder will raise an exception if the binary data to be decoded
+is not padded to the next 32-byte boundary. This behavior can be disabled for the
+``ByteStringDecoder`` (the default decoder for ``bytes`` and ``string`` types) by
+passing ``strict=False`` to the :py:meth:`eth_abi.abi.decode` method. Turning off
+strict mode will also ignore any trailing bytes beyond the data size specified. This
+means that if there is any padding, the validation for only empty bytes in the padding
+area is also ignored.
+
+.. doctest::
+
+    >>> from eth_abi import abi
+
+    >>> # decode a bytes value without strict mode
+    >>> hex_val = (
+    ...     # offset to data is 32 bytes:
+    ...     "0000000000000000000000000000000000000000000000000000000000000020"
+    ...     # length of data is 1 byte:
+    ...     "0000000000000000000000000000000000000000000000000000000000000001"
+    ...     # b"\x01" with less than 32 bytes of padding
+    ...     # and not strictly padded with only zero bytes:
+    ...     "0100000000000001020300"
+    ... )
+    >>> (decoded,) = abi.decode(['bytes'], bytes.fromhex(hex_val), strict=False)
+    >>> decoded
+    b'\x01'

--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -139,11 +139,10 @@ class ABIDecoder(BaseABICoder):
         :param types: A list or tuple of string representations of the ABI types that
             will be used for decoding e.g. ``('uint256', 'bytes[]', '(int,int)')``
         :param data: The binary value to be decoded.
-        :param strict: If ``False``, then the decoder will ignore properties such as
-            the length of the data being a multiple of 32 bytes. ``False`` is how the
-            Solidity ABI decoder currently works. However, ``True`` is the default for
-            the eth-abi library.
-
+        :param strict: If ``False``, dynamic-type decoders will ignore validations such
+            as making sure the data is padded to a multiple of 32 bytes or checking that
+            padding bytes are zero / empty. ``False`` is how the Solidity ABI decoder
+            currently works. However, ``True`` is the default for the eth-abi library.
 
         :returns: A tuple of equivalent python values for the ABI values
             represented in ``data``.

--- a/eth_abi/codec.py
+++ b/eth_abi/codec.py
@@ -129,6 +129,7 @@ class ABIDecoder(BaseABICoder):
         self,
         types: Iterable[TypeStr],
         data: Decodable,
+        strict: bool = True,
     ) -> Tuple[Any, ...]:
         """
         Decodes the binary value ``data`` as a sequence of values of the ABI types
@@ -138,6 +139,11 @@ class ABIDecoder(BaseABICoder):
         :param types: A list or tuple of string representations of the ABI types that
             will be used for decoding e.g. ``('uint256', 'bytes[]', '(int,int)')``
         :param data: The binary value to be decoded.
+        :param strict: If ``False``, then the decoder will ignore properties such as
+            the length of the data being a multiple of 32 bytes. ``False`` is how the
+            Solidity ABI decoder currently works. However, ``True`` is the default for
+            the eth-abi library.
+
 
         :returns: A tuple of equivalent python values for the ABI values
             represented in ``data``.
@@ -146,7 +152,9 @@ class ABIDecoder(BaseABICoder):
         validate_list_like_param(types, "types")
         validate_bytes_param(data, "data")
 
-        decoders = [self._registry.get_decoder(type_str) for type_str in types]
+        decoders = [
+            self._registry.get_decoder(type_str, strict=strict) for type_str in types
+        ]
 
         decoder = TupleDecoder(decoders=decoders)
         stream = self.stream_class(data)

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -516,6 +516,10 @@ class ByteStringDecoder(SingleDecoder):
         data = stream.read(padded_length)
 
         if len(data) < padded_length:
+            if len(data) == data_length:
+                # padding does not exist
+                return data
+
             raise InsufficientDataBytes(
                 "Tried to read {0} bytes.  Only got {1} bytes".format(
                     padded_length,

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -305,10 +305,8 @@ class FixedByteSizeDecoder(SingleDecoder):
 
         if len(data) != self.data_byte_size:
             raise InsufficientDataBytes(
-                "Tried to read {0} bytes.  Only got {1} bytes".format(
-                    self.data_byte_size,
-                    len(data),
-                )
+                f"Tried to read {self.data_byte_size} bytes, "
+                f"only got {len(data)} bytes."
             )
 
         return data
@@ -332,7 +330,7 @@ class FixedByteSizeDecoder(SingleDecoder):
 
         if padding_bytes != b"\x00" * padding_size:
             raise NonEmptyPaddingBytes(
-                "Padding bytes were not empty: {0}".format(repr(padding_bytes))
+                f"Padding bytes were not empty: {repr(padding_bytes)}"
             )
 
     def _get_value_byte_size(self):
@@ -413,7 +411,7 @@ class SignedIntegerDecoder(Fixed32ByteSizeDecoder):
 
         if padding_bytes != expected_padding_bytes:
             raise NonEmptyPaddingBytes(
-                "Padding bytes were not empty: {0}".format(repr(padding_bytes))
+                f"Padding bytes were not empty: {repr(padding_bytes)}"
             )
 
     @parse_type_str("int")
@@ -490,7 +488,7 @@ class SignedFixedDecoder(BaseFixedDecoder):
 
         if padding_bytes != expected_padding_bytes:
             raise NonEmptyPaddingBytes(
-                "Padding bytes were not empty: {0}".format(repr(padding_bytes))
+                f"Padding bytes were not empty: {repr(padding_bytes)}"
             )
 
     @parse_type_str("fixed")
@@ -515,28 +513,18 @@ class ByteStringDecoder(SingleDecoder):
         padded_length = ceil32(data_length)
 
         data = stream.read(padded_length)
-        padding_bytes = data[data_length:]
 
-        if len(data) < padded_length:
-            if not self.strict:
-                data_length = padded_length
-                padding_bytes = data[data_length:]
-            else:
+        if self.strict:
+            if len(data) < padded_length:
                 raise InsufficientDataBytes(
-                    "Tried to read {0} bytes.  Only got {1} bytes".format(
-                        padded_length,
-                        len(data),
-                    )
+                    f"Tried to read {padded_length} bytes, only got {len(data)} bytes"
                 )
 
-        if padding_bytes != b"\x00" * (padded_length - data_length):
-            raise NonEmptyPaddingBytes(
-                "Padding bytes were not empty: {0}".format(repr(padding_bytes))
-            )
-
-        if not self.strict:
-            # remove trailing zero-byte padding
-            return data[:data_length].rstrip(b"\x00")
+            padding_bytes = data[data_length:]
+            if padding_bytes != b"\x00" * (padded_length - data_length):
+                raise NonEmptyPaddingBytes(
+                    f"Padding bytes were not empty: {repr(padding_bytes)}"
+                )
 
         return data[:data_length]
 

--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -7,7 +7,7 @@ from typing import (
 
 from eth_utils import (
     big_endian_to_int,
-    to_bytes, to_hex, to_normalized_address,
+    to_normalized_address,
     to_tuple,
 )
 
@@ -536,7 +536,7 @@ class ByteStringDecoder(SingleDecoder):
 
         if not self.strict:
             # remove trailing zero-byte padding
-            return to_bytes(hexstr=to_hex(data[:data_length]).rstrip("00"))
+            return data[:data_length].rstrip(b"\x00")
 
         return data[:data_length]
 

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -488,7 +488,7 @@ class ABIRegistry(Copyable, BaseRegistry):
     def get_decoder(self, type_str, strict=True):
         decoder = self._get_registration(self._decoders, type_str)
 
-        if decoder.is_dynamic:
+        if hasattr(decoder, "is_dynamic") and decoder.is_dynamic:
             # Set a transient flag each time a call is made to ``get_decoder()``.
             # Only dynamic decoders should be allowed these looser constraints. All
             # other decoders should keep the default value of ``True``.

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -488,8 +488,12 @@ class ABIRegistry(Copyable, BaseRegistry):
     def get_decoder(self, type_str, strict=True):
         decoder = self._get_registration(self._decoders, type_str)
 
-        # set a transient flag each time a call is made to get_decoder
-        decoder.strict = strict
+        if decoder.is_dynamic:
+            # Set a transient flag each time a call is made to ``get_decoder()``.
+            # Only dynamic decoders should be allowed these looser constraints. All
+            # other decoders should keep the default value of ``True``.
+            decoder.strict = strict
+
         return decoder
 
     def copy(self):

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -485,8 +485,12 @@ class ABIRegistry(Copyable, BaseRegistry):
         return True
 
     @functools.lru_cache(maxsize=None)
-    def get_decoder(self, type_str):
-        return self._get_registration(self._decoders, type_str)
+    def get_decoder(self, type_str, strict=True):
+        decoder = self._get_registration(self._decoders, type_str)
+
+        # set a transient flag each time a call is made to get_decoder
+        decoder.strict = strict
+        return decoder
 
     def copy(self):
         """

--- a/newsfragments/198.feature.rst
+++ b/newsfragments/198.feature.rst
@@ -1,0 +1,1 @@
+Allow turning off abi decoder "strict mode" when calling ``abi.decode()``.

--- a/tests/abi/test_decode.py
+++ b/tests/abi/test_decode.py
@@ -108,3 +108,8 @@ def test_abi_decode_raises_for_zero_sized_tuple_type(zero_sized_tuple_type):
         match=re.escape('Zero-sized tuple types "()" are not supported.'),
     ):
         decode([zero_sized_tuple_type], b"bytes data shouldn't matter for validation")
+
+
+def test_abi_decode_with_shorter_data_than_32_bytes():
+    data = b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    assert decode(["bytes"], data, strict=False) == (1,)

--- a/tests/abi/test_decode.py
+++ b/tests/abi/test_decode.py
@@ -110,6 +110,74 @@ def test_abi_decode_raises_for_zero_sized_tuple_type(zero_sized_tuple_type):
         decode([zero_sized_tuple_type], b"bytes data shouldn't matter for validation")
 
 
-def test_abi_decode_with_shorter_data_than_32_bytes():
-    data = b"\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-    assert decode(["bytes"], data, strict=False) == (1,)
+@pytest.mark.parametrize(
+    "types,hex_data,expected",
+    (
+        (
+            ["string"],
+            (
+                "0000000000000000000000000000000000000000000000000000000000000020"
+                "0000000000000000000000000000000000000000000000000000000000000011"
+                "6e6f2070616464696e67206e6565646564"
+            ),
+            ("no padding needed",),
+        ),
+        (
+            ["bytes"],
+            (
+                # offset to data is 32 bytes:
+                "0000000000000000000000000000000000000000000000000000000000000020"
+                # length of data is 1 byte:
+                "0000000000000000000000000000000000000000000000000000000000000001"
+                # b"\x01" with less than 32 bytes of padding:
+                "01000000000000000000"
+            ),
+            (b"\x01",),
+        ),
+        (
+            # example from issue #198
+            ["uint256", "uint256", "address", "bytes"],
+            (
+                # uint256 with value of 891276594009425425420:
+                "00000000000000000000000000000000000000000000003050f28c10d7d9b40c"
+                # uint256 with value of 0:
+                "0000000000000000000000000000000000000000000000000000000000000000"
+                # address:
+                "000000000000000000000000b5c7ad3cb6506c65da01f2fac2e667dcb9e66e9c"
+                # data starts at 128 bytes into the byte array:
+                "0000000000000000000000000000000000000000000000000000000000000080"
+                # 201 bytes of data (padded would've been 224 bytes):
+                "00000000000000000000000000000000000000000000000000000000000000c9"
+                "04853d955acef822db058eb8505911ed77f175b99e1531c1a63a169ac75a2daa"
+                "e399080745fa51de440000000000000000000000000000000000000000000000"
+                "3050f28c10d7d9b40c7bc2c873190bbaddefe646c35f1ae6cffbfb402059bd67"
+                "74c22486d9f4fab2d448dce4f892a9ae250d0ab87046fbb341d058f17cbc4c11"
+                "33f25a20a52f000db63cac384247597756545b500253ff8e607a8020010b0002"
+                "0f0100000e030c01990966d504030200000569b81152c5a8d35a67b32a4d3772"
+                "795d96cae4da010106"
+            ),
+            (
+                891276594009425425420,
+                0,
+                "0xb5c7ad3cb6506c65da01f2fac2e667dcb9e66e9c",
+                b'\x04\x85=\x95Z\xce\xf8"\xdb\x05\x8e\xb8PY\x11\xedw\xf1u\xb9\x9e'
+                b"\x151\xc1\xa6:\x16\x9a\xc7Z-\xaa\xe3\x99\x08\x07E\xfaQ\xdeD\x00"
+                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                b"\x00\x00\x00\x00\x00\x000P\xf2\x8c\x10\xd7\xd9\xb4\x0c{\xc2\xc8s"
+                b"\x19\x0b\xba\xdd\xef\xe6F\xc3_\x1a\xe6\xcf\xfb\xfb@ Y\xbdgt\xc2$"
+                b"\x86\xd9\xf4\xfa\xb2\xd4H\xdc\xe4\xf8\x92\xa9\xae%\r\n\xb8pF\xfb"
+                b"\xb3A\xd0X\xf1|\xbcL\x113\xf2Z \xa5/\x00\r\xb6<\xac8BGYwVT[P\x02S"
+                b"\xff\x8e`z\x80 \x01\x0b\x00\x02\x0f\x01\x00\x00\x0e\x03\x0c\x01"
+                b"\x99\tf\xd5\x04\x03\x02\x00\x00\x05i\xb8\x11R\xc5\xa8\xd3Zg"
+                b"\xb3*M7ry]\x96\xca\xe4\xda\x01\x01\x06",
+            ),
+        ),
+    ),
+)
+def test_abi_decode_with_shorter_data_than_32_bytes(types, hex_data, expected):
+    assert decode(types, bytes.fromhex(hex_data), strict=False) == expected
+
+    # assert flag is transient and does not affect other calls to ``decode()``
+    # without the flag set (i.e. assert the default behavior is always ``strict=True``).
+    with pytest.raises(InsufficientDataBytes):
+        decode(types, bytes.fromhex(hex_data))

--- a/tests/decoding/test_decoder_properties.py
+++ b/tests/decoding/test_decoder_properties.py
@@ -214,7 +214,7 @@ def test_decode_bytes(_bytes, pad_size):
 
     decoder = ByteStringDecoder()
 
-    if len(padded_bytes) < ceil32(len(_bytes)):
+    if pad_size != 0 and len(padded_bytes) < ceil32(len(_bytes)):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
@@ -236,7 +236,7 @@ def test_decode_strings(_strings, pad_size):
 
     decoder = StringDecoder()
 
-    if len(padded_bytes) < ceil32(len(_strings.encode("utf-8"))):
+    if pad_size != 0 and len(padded_bytes) < ceil32(len(_strings.encode("utf-8"))):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
@@ -267,7 +267,7 @@ def test_decode_strings_error_handling(_bytes, pad_size, handle_string_errors, e
     stream = ContextFramesBytesIO(stream_bytes)
     decoder = StringDecoder(handle_string_errors=handle_string_errors)
 
-    if len(padded_bytes) < ceil32(len(_bytes)):
+    if pad_size != 0 and len(padded_bytes) < ceil32(len(_bytes)):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return

--- a/tests/decoding/test_decoder_properties.py
+++ b/tests/decoding/test_decoder_properties.py
@@ -214,7 +214,7 @@ def test_decode_bytes(_bytes, pad_size):
 
     decoder = ByteStringDecoder()
 
-    if pad_size != 0 and len(padded_bytes) < ceil32(len(_bytes)):
+    if len(padded_bytes) < ceil32(len(_bytes)):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
@@ -236,7 +236,7 @@ def test_decode_strings(_strings, pad_size):
 
     decoder = StringDecoder()
 
-    if pad_size != 0 and len(padded_bytes) < ceil32(len(_strings.encode("utf-8"))):
+    if len(padded_bytes) < ceil32(len(_strings.encode("utf-8"))):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return
@@ -267,7 +267,7 @@ def test_decode_strings_error_handling(_bytes, pad_size, handle_string_errors, e
     stream = ContextFramesBytesIO(stream_bytes)
     decoder = StringDecoder(handle_string_errors=handle_string_errors)
 
-    if pad_size != 0 and len(padded_bytes) < ceil32(len(_bytes)):
+    if len(padded_bytes) < ceil32(len(_bytes)):
         with pytest.raises(InsufficientDataBytes):
             decoder(stream)
         return


### PR DESCRIPTION
### What was wrong?

closes #198

### How was it fixed?

@jad-elmourad:
- Allow decoding arbitrary length bytes without padding

@fselmo:
- Introduce this as a feature by allowing the default "strict mode" behavior for the ``BytesStringDecoder`` to be turned off via a ``strict`` flag that is ``True`` by default. The current behavior of the library is ``strict=True`` so this shouldn't be a breaking change. When ``strict=False``, the behavior desired in #198 is enabled.

- Add some testing around this and make sure all other decoding tests pass whether the ``strict`` flag is ``True`` or ``False``.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/50577/hedgehog-animal-baby-cute-50577.jpeg)