### PR TITLE
add build.os section to rtd yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 python:
   install:
     - method: pip

--- a/newsfragments/213.internal.rst
+++ b/newsfragments/213.internal.rst
@@ -1,0 +1,1 @@
+Add ``build.os`` section to readthedocs build settings


### PR DESCRIPTION
### What was wrong?

ReadTheDocs builds started failing a few days ago. Apparently the `readthedocs.yml` requires a `build.os` to be specified going forward.

### How was it fixed?

Added the required section.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-abi/assets/5199899/e905ce29-975d-497b-a5ca-70cefba06ae4)
