### PR TITLE
Remove pkg_resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib
 lib64
 pip-wheel-metadata
 venv*
+.venv*
 
 # Installer logs
 pip-log.txt

--- a/eth_abi/__init__.py
+++ b/eth_abi/__init__.py
@@ -1,4 +1,16 @@
-import pkg_resources
+try:
+    from importlib.metadata import (
+        version as __version,
+    )
+except ImportError:
+    # Python 3.7
+    def __version(package_name: str) -> str:  # type: ignore
+        from pkg_resources import (
+            get_distribution,
+        )
+
+        return get_distribution(package_name).version
+
 
 from eth_abi.abi import (  # NOQA
     decode,
@@ -7,4 +19,4 @@ from eth_abi.abi import (  # NOQA
     is_encodable_type,
 )
 
-__version__ = pkg_resources.get_distribution("eth-abi").version
+__version__ = __version("eth-abi")

--- a/newsfragments/214.misc.rst
+++ b/newsfragments/214.misc.rst
@@ -1,0 +1,1 @@
+Use ``importlib`` to replace ``pkg_resources`` (deprecated) in Python >= 3.8.


### PR DESCRIPTION
### What was wrong?

This package is deprecated

Related to Issue  https://github.com/ethereum/eth-utils/issues/242
Closes # NA

### How was it fixed?

Remove pkg_resources import above 3.8

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/master/newsfragments/README.md)

#### Cute Animal Picture


