### PR TITLE
Add tests for decoding `bytes` at different positions

### DIFF
--- a/newsfragments/222.internal.rst
+++ b/newsfragments/222.internal.rst
@@ -1,0 +1,1 @@
+Add examples to ``test_decoder_properties`` tests for decoding ``bytes`` type.


### PR DESCRIPTION
### What was wrong?

Closes #222

### How was it fixed?

Add tests to illustrate differences passing additional topics to `decode`.

### Todo:

- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="396" alt="Screen Shot 2024-02-14 at 1 58 55 PM" src="https://github.com/ethereum/eth-abi/assets/435903/53a0c633-8175-4e54-bf1c-299fb913fda1">
