### PR TITLE
🚨 fix linting warning (rule B019)

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -44,6 +44,9 @@ class NodeVisitor(parsimonious.NodeVisitor):  # type: ignore[misc] # subclasses 
     post-processing of parse trees.  Parsing operations are cached.
     """
 
+    def __init__(self):
+        self.parse = functools.lru_cache(maxsize=None)(self._parse_uncached)
+
     grammar = grammar
 
     def visit_non_zero_tuple(self, node, visited_children):
@@ -103,8 +106,7 @@ class NodeVisitor(parsimonious.NodeVisitor):  # type: ignore[misc] # subclasses 
 
         return tuple(visited_children)
 
-    @functools.lru_cache(maxsize=None)  # noqa: B019
-    def parse(self, type_str, **kwargs):
+    def _parse_uncached(self, type_str, **kwargs):
         """
         Parses a type string into an appropriate instance of
         :class:`~eth_abi.grammar.ABIType`.  If a type string cannot be parsed,

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -344,6 +344,8 @@ class ABIRegistry(Copyable, BaseRegistry):
     def __init__(self):
         self._encoders = PredicateMapping("encoder registry")
         self._decoders = PredicateMapping("decoder registry")
+        self.get_encoder = functools.lru_cache(maxsize=None)(self._get_encoder_uncached)
+        self.get_decoder = functools.lru_cache(maxsize=None)(self._get_decoder_uncached)
 
     def _get_registration(self, mapping, type_str):
         coder = super()._get_registration(mapping, type_str)
@@ -451,8 +453,7 @@ class ABIRegistry(Copyable, BaseRegistry):
         self.unregister_encoder(label)
         self.unregister_decoder(label)
 
-    @functools.lru_cache(maxsize=None)  # noqa: B019
-    def get_encoder(self, type_str):
+    def _get_encoder_uncached(self, type_str):
         return self._get_registration(self._encoders, type_str)
 
     def has_encoder(self, type_str: abi.TypeStr) -> bool:
@@ -471,8 +472,7 @@ class ABIRegistry(Copyable, BaseRegistry):
 
         return True
 
-    @functools.lru_cache(maxsize=None)  # noqa: B019
-    def get_decoder(self, type_str, strict=True):
+    def _get_decoder_uncached(self, type_str, strict=True):
         decoder = self._get_registration(self._decoders, type_str)
 
         if hasattr(decoder, "is_dynamic") and decoder.is_dynamic:

--- a/newsfragments/230.bugfix.rst
+++ b/newsfragments/230.bugfix.rst
@@ -1,0 +1,1 @@
+Fix memory leak warning in NodeVisitor and ABIRegistry


### PR DESCRIPTION
### What was wrong?
The codebase currently use the `lru_cache` decorator in the `NodeVisitor` and `ABIRegistry` classes over methods. The `flake8-bugbear` linter reported a `B019` warning, indicating potential memory leaks in class methods. The `lru_cache` decorator retain instance references, impeding garbage collection and potentially leading to memory-related issues.

Related to Issue #218
Closes #218 

### How was it fixed?
We don't have to replace `lru_cache` with something else for solve linter warning. This problem can be solved in the following way: we stopped using decorators directly over methods. Instead we apply the decorator function when initializing a class instance.

### Todo:

- [x] Clean up commit history

- [ ] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://i.pinimg.com/564x/a8/a3/79/a8a379d07b5071add37dd24ae3ab8ee1.jpg>)
