### PR TITLE
Upgrade `parsimonious` to `0.10`

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -93,11 +93,12 @@ class NodeVisitor(parsimonious.NodeVisitor):  # type: ignore[misc] # subclasses 
         return int(node.text)
 
     def generic_visit(self, node, visited_children):
-        if isinstance(node.expr, expressions.OneOf):
+        expr = node.expr
+        if isinstance(expr, expressions.OneOf):
             # Unwrap value chosen from alternatives
             return visited_children[0]
 
-        if isinstance(node.expr, expressions.Optional):
+        if isinstance(expr, expressions.Quantifier) and expr.min == 0 and expr.max == 1:
             # Unwrap optional value or return `None`
             if len(visited_children) != 0:
                 return visited_children[0]

--- a/newsfragments/231.internal.rst
+++ b/newsfragments/231.internal.rst
@@ -1,0 +1,1 @@
+Upgrade `parsimonious <https://github.com/erikrose/parsimonious>`_ from ``0.9`` to ``0.10``, which is 15% faster

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     install_requires=[
         "eth-utils>=2.0.0",
         "eth-typing>=3.0.0",
-        "parsimonious>=0.9.0,<0.10.0",
+        "parsimonious>=0.10.0,<0.11.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,


### PR DESCRIPTION
### What was wrong?

The `parsimonious` dep was pinned to an outdated version.

The 0.10.0 release includes bugfixes and performance improvements, see https://github.com/erikrose/parsimonious?tab=readme-ov-file#version-history.

The breaking change that's mentioned shouldn't affect the grammar that's used here, as it used spaces where relevant.

### How was it fixed?

Sheer willpower.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![The shoebill](https://i.imgur.com/X9QFgHf.png)

> The shoebill (Balaeniceps rex), also known as the whalebill, whale-headed stork, and shoe-billed stork is a large long-legged wading bird.

[[Wikipedia - Shoebill](https://wikipedia.org/wiki/Shoebill)]