### PR TITLE
fix: handle `strict=False` when decoding uint256

### DIFF
--- a/eth_abi/decoding.py
+++ b/eth_abi/decoding.py
@@ -386,10 +386,17 @@ class FixedByteSizeDecoder(SingleDecoder):
         data = stream.read(self.data_byte_size)
 
         if len(data) != self.data_byte_size:
-            raise InsufficientDataBytes(
-                f"Tried to read {self.data_byte_size} bytes, "
-                f"only got {len(data)} bytes."
-            )
+            if self.strict:
+                raise InsufficientDataBytes(
+                    f"Tried to read {self.data_byte_size} bytes, "
+                    f"only got {len(data)} bytes."
+                )
+
+            # Pad the value.
+            data_stripped = data.lstrip(b"\x00")
+            num_zeroes = max(0, 32 - len(data_stripped))
+            zeroes = b"\x00" * num_zeroes
+            data = zeroes + data_stripped
 
         return data
 

--- a/eth_abi/registry.py
+++ b/eth_abi/registry.py
@@ -474,13 +474,7 @@ class ABIRegistry(Copyable, BaseRegistry):
 
     def _get_decoder_uncached(self, type_str, strict=True):
         decoder = self._get_registration(self._decoders, type_str)
-
-        if hasattr(decoder, "is_dynamic") and decoder.is_dynamic:
-            # Set a transient flag each time a call is made to ``get_decoder()``.
-            # Only dynamic decoders should be allowed these looser constraints. All
-            # other decoders should keep the default value of ``True``.
-            decoder.strict = strict
-
+        decoder.strict = strict
         return decoder
 
     def copy(self):


### PR DESCRIPTION
### What was wrong?

Related to Issue #227
Closes #227 

### How was it fixed?

if self.strict is False, pad the value with leading zeroes to 32 bytes instead.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

https://www.publicdomainpictures.net/pictures/250000/velka/alaskan-husky.jpg