### PR TITLE
docs: fix the installation package

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Installation
 
 .. code-block:: bash
 
-    python -m pip install Ethereum Contract Interface (ABI) Utility
+    python -m pip install eth-abi
 
 Table of Contents
 -----------------

--- a/newsfragments/243.docs.rst
+++ b/newsfragments/243.docs.rst
@@ -1,0 +1,1 @@
+Fix typo in index


### PR DESCRIPTION
### What was wrong?

The package's name to install is wrong in the documentation.