### PR TITLE
feat: cache result of ABIType.to_type_str

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from typing import Optional
 
 import parsimonious
 from parsimonious import (
@@ -235,6 +236,12 @@ class TupleType(ABIType):
         tuple type's components.
         """
 
+        self._type_str: Optional[str] = None
+        """
+        The string representation of an ABI type.  Once populated,
+        this will be equal to the type string from which it was created.
+        """  # NOTE: wait then why dont we just set it now from the init arg? 
+
     def to_type_str(self) -> str:
         type_str = self._type_str
         if type_str is None:
@@ -295,6 +302,12 @@ class BasicType(ABIType):
         for "ufixed128x18" etc.  Equal to ``None`` if type string has no sub
         type.
         """
+
+        self._type_str: Optional[str] = None
+        """
+        The string representation of an ABI type.  Once populated,
+        this will be equal to the type string from which it was created.
+        """  # NOTE: wait then why dont we just set it now from the init arg? 
 
     def to_type_str(self):
         type_str = self._type_str

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -240,7 +240,7 @@ class TupleType(ABIType):
         """
         The string representation of an ABI type.  Once populated,
         this will be equal to the type string from which it was created.
-        """  # NOTE: wait then why dont we just set it now from the init arg? 
+        """
 
     def to_type_str(self) -> str:
         type_str = self._type_str
@@ -307,7 +307,7 @@ class BasicType(ABIType):
         """
         The string representation of an ABI type.  Once populated,
         this will be equal to the type string from which it was created.
-        """  # NOTE: wait then why dont we just set it now from the init arg? 
+        """
 
     def to_type_str(self):
         type_str = self._type_str

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -224,7 +224,7 @@ class TupleType(ABIType):
     Represents the result of parsing a tuple type string e.g. "(int,bool)".
     """
 
-    __slots__ = ("components",)
+    __slots__ = ("components", "_type_str")
 
     def __init__(self, components, arrlist=None, *, node=None):
         super().__init__(arrlist, node)
@@ -235,15 +235,20 @@ class TupleType(ABIType):
         tuple type's components.
         """
 
-    def to_type_str(self):
-        arrlist = self.arrlist
-
-        if isinstance(arrlist, tuple):
-            arrlist = "".join(repr(list(a)) for a in arrlist)
-        else:
-            arrlist = ""
-
-        return f"({','.join(c.to_type_str() for c in self.components)}){arrlist}"
+    def to_type_str(self) -> str:
+        type_str = self._type_str
+        if type_str is None:
+            arrlist = self.arrlist
+    
+            if isinstance(arrlist, tuple):
+                arrlist = "".join(repr(list(a)) for a in arrlist)
+            else:
+                arrlist = ""
+    
+            type_str = self._type_str = (
+                f"({','.join(c.to_type_str() for c in self.components)}){arrlist}"
+            )
+        return type_str
 
     @property
     def item_type(self):
@@ -276,7 +281,7 @@ class BasicType(ABIType):
     "ufixed128x19[][2]".
     """
 
-    __slots__ = ("base", "sub")
+    __slots__ = ("base", "sub", "_type_str")
 
     def __init__(self, base, sub=None, arrlist=None, *, node=None):
         super().__init__(arrlist, node)
@@ -292,21 +297,24 @@ class BasicType(ABIType):
         """
 
     def to_type_str(self):
-        sub, arrlist = self.sub, self.arrlist
-
-        if isinstance(sub, int):
-            sub = str(sub)
-        elif isinstance(sub, tuple):
-            sub = "x".join(str(s) for s in sub)
-        else:
-            sub = ""
-
-        if isinstance(arrlist, tuple):
-            arrlist = "".join(repr(list(a)) for a in arrlist)
-        else:
-            arrlist = ""
-
-        return self.base + sub + arrlist
+        type_str = self._type_str
+        if type_str is None:
+            sub, arrlist = self.sub, self.arrlist
+    
+            if isinstance(sub, int):
+                sub = str(sub)
+            elif isinstance(sub, tuple):
+                sub = "x".join(str(s) for s in sub)
+            else:
+                sub = ""
+    
+            if isinstance(arrlist, tuple):
+                arrlist = "".join(repr(list(a)) for a in arrlist)
+            else:
+                arrlist = ""
+    
+            type_str = self._type_str = self.base + sub + arrlist
+        return type_str
 
     @property
     def item_type(self):


### PR DESCRIPTION
### What was wrong?
ABIType.to_type_str can be called multiple times on an instance, so its result should be cached for better performance

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
