### PR TITLE
feat: make ABIType a singleton type

### DIFF
--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -207,6 +207,9 @@ class ABIType(metaclass=_ABITypeSingletonMeta):
     def __repr__(self):  # pragma: no cover
         return f"<{type(self).__qualname__} {repr(self.to_type_str())}>"
 
+    def __hash__(self) -> int:
+        return id(self)
+
     def __eq__(self, other):
         # Two ABI types are equal if their string representations are equal
         return type(self) is type(other) and self.to_type_str() == other.to_type_str()

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from typing import Any, Dict, 
+from typing import Any, Dict, Tuple
 
 import parsimonious
 from parsimonious import (

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -172,7 +172,7 @@ class _ABITypeSingletonMeta(type):
             kwargs_key.append(k)
             v = init_kwargs[k]
             kwargs_key.append(
-                pickle.dumps(v)  # Node isn't hashable but its pickle representation is
+                repr(v)  # Node isn't hashable but has a special repr method which makes it's repr suitable for use as a key
                 if isinstance(v, Node)
                 else tuple(v)
                 if isinstance(v, list)

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from pickle import pickle
 from typing import Any, Dict, Tuple
 
 import parsimonious

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,5 +1,6 @@
 import functools
 import re
+from typing import Any, Dict, 
 
 import parsimonious
 from parsimonious import (
@@ -148,17 +149,20 @@ class _ABITypeSingletonMeta(type):
 
         super().__init__(name, bases, namespace)
 
-        self.__instances__ = {}
+        self.__instances__: Dict[Tuple[Any, ...], Any] = {}
         """A cache that holds the singleton instance for each key."""
 
     def __call__(self, *init_args, **init_kwargs):
+        key = self._make_key(init_args, init_kwargs)
         singleton = self.__instances__.get(key)
         if singleton is None:
             singleton = super().__call__(*init_args, **init_kwargs)
             self.__instances__[key] = singleton
         return singleton
 
-    def _make_key(self, *init_args, **init_kwargs) -> tuple:
+    def _make_key(self, init_args: Tuple[Any, ...], init_kwargs: Dict[str, Any]) -> Tuple[Any, ...]:
+        # TODO: optimize this a bit better, we can know the init args at the time of class
+        # creation so we should use that info since this code is called in tight loops
         kwargs_key = []
         for k in sorted(init_kwargs):
             kwargs_key.append(k)

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -152,12 +152,21 @@ class _ABITypeSingletonMeta(type):
         """A cache that holds the singleton instance for each key."""
 
     def __call__(self, *init_args, **init_kwargs):
-        singleton = init_args, tuple((k, init_kwargs[k]) for k in sorted(init_kwargs))
         singleton = self.__instances__.get(key)
         if singleton is None:
             singleton = super().__call__(*init_args, **init_kwargs)
             self.__instances__[key] = singleton
         return singleton
+
+    def _make_key(self, *init_args, **init_kwargs) -> tuple:
+        kwargs_key = []
+        for k in sorted(init_kwargs):
+            kwargs_key.append(k)
+            v = init_kwargs[k]
+            kwargs_key.append(tuple(v) if isinstance(v, list) else v)
+        # should be quicker to hash if we just make 1 tuple with unpacked values
+        return *init_args, *kwargs_key
+        
 
 
 class ABIType(metaclass=_ABITypeSingletonMeta):

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,6 +1,6 @@
 import functools
+import pickle
 import re
-from pickle import pickle
 from typing import Any, Dict, Tuple
 
 import parsimonious
@@ -172,7 +172,7 @@ class _ABITypeSingletonMeta(type):
             kwargs_key.append(k)
             v = init_kwargs[k]
             kwargs_key.append(
-                pickle(v)  # Node isn't hashable but its pickle representation is
+                pickle.dumps(v)  # Node isn't hashable but its pickle representation is
                 if isinstance(v, Node)
                 else tuple(v)
                 if isinstance(v, list)

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -1,5 +1,4 @@
 import functools
-import pickle
 import re
 from typing import Any, Dict, Tuple
 
@@ -172,7 +171,9 @@ class _ABITypeSingletonMeta(type):
             kwargs_key.append(k)
             v = init_kwargs[k]
             kwargs_key.append(
-                repr(v)  # Node isn't hashable but has a special repr method which makes it's repr suitable for use as a key
+                repr(v)
+                # Node isn't hashable but has a special repr method which makes it's repr suitable for use as a key
+                # TODO: PR a hash method to parsimonius, they already describe a Node as immutable
                 if isinstance(v, Node)
                 else tuple(v)
                 if isinstance(v, list)

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -167,7 +167,13 @@ class _ABITypeSingletonMeta(type):
         for k in sorted(init_kwargs):
             kwargs_key.append(k)
             v = init_kwargs[k]
-            kwargs_key.append(tuple(v) if isinstance(v, list) else v)
+            kwargs_key.append(
+                pickle(v)  # Node isn't hashable but its pickle representation is
+                if isinstance(v, Node)
+                else tuple(v)
+                if isinstance(v, list)
+                else v
+            )
         # should be quicker to hash if we just make 1 tuple with unpacked values
         return *init_args, *kwargs_key
         

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -6,6 +6,9 @@ import parsimonious
 from parsimonious import (
     expressions,
 )
+from parsimonius.nodes import (
+    Node,
+)
 
 from eth_abi.exceptions import (
     ABITypeError,

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -6,7 +6,7 @@ import parsimonious
 from parsimonious import (
     expressions,
 )
-from parsimonius.nodes import (
+from parsimonious.nodes import (
     Node,
 )
 

--- a/eth_abi/grammar.py
+++ b/eth_abi/grammar.py
@@ -135,7 +135,32 @@ class NodeVisitor(parsimonious.NodeVisitor):  # type: ignore[misc] # subclasses 
 visitor = NodeVisitor()
 
 
-class ABIType:
+class _ABITypeSingletonMeta(type):
+    def __init__(self, name, bases, namespace):
+        """
+        Initialize the metaclass with a name, bases, and namespace.
+
+        Args:
+            name: The name of the class being created.
+            bases: A tuple of base classes.
+            namespace: A dictionary representing the class namespace.
+        """
+
+        super().__init__(name, bases, namespace)
+
+        self.__instances__ = {}
+        """A cache that holds the singleton instance for each key."""
+
+    def __call__(self, *init_args, **init_kwargs):
+        singleton = init_args, tuple((k, init_kwargs[k]) for k in sorted(init_kwargs))
+        singleton = self.__instances__.get(key)
+        if singleton is None:
+            singleton = super().__call__(*init_args, **init_kwargs)
+            self.__instances__[key] = singleton
+        return singleton
+
+
+class ABIType(metaclass=_ABITypeSingletonMeta):
     """
     Base class for results of type string parsing operations.
     """


### PR DESCRIPTION
Since ABIType objects are immutable, and downstream libraries rapidly create, use, and destroy them, I've made ABIType into a singleton class by giving it a specialized metaclass.

This allows caching stuff like my previous PR to work even better, and will not cause any leaky memory issues because the number of types is constrained.

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-abi/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
